### PR TITLE
feat: improved caching

### DIFF
--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -1021,6 +1021,14 @@ sequenceDiagram
     end
 ```
 
+### Job cache
+
+Jobs are cached in the following way. When you request to create a job, the payload and type are cached. Job(s) in the system may exist with this hash - these are retrieved. If no matching hashes, then the job is created and cached is false in the response. If there are matches, we first disregard failed jobs (so we aren't hitting stale fails in the job system), then sort by status (succeeded is priority), then by time (newest first). The 'best' cached result is returned, by letting the user instead know about the existing ID, rather than a new item.
+
+This request is still logged as a JobRequest, however no new Job is created.
+
+The interface can then blindly accept the job ID and poll it as usual, finding in this case that there may be a successful result already.
+
 ### API Routes
 
 #### Job Management
@@ -1048,14 +1056,14 @@ Example job type configuration:
 const jobTypeSchemas = {
   SUITABILITY_ASSESSMENT: {
     input: z.object({
-      fieldsHere: z.string(),
+      fieldsHere: z.string()
     }),
     result: z
       .object({
-        fieldsHere: z.string(),
+        fieldsHere: z.string()
       })
-      .optional(),
-  },
+      .optional()
+  }
 };
 ```
 

--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -1023,7 +1023,7 @@ sequenceDiagram
 
 ### Job cache
 
-Jobs are cached in the following way. When you request to create a job, the payload and type are cached. Job(s) in the system may exist with this hash - these are retrieved. If no matching hashes, then the job is created and cached is false in the response. If there are matches, we first disregard failed jobs (so we aren't hitting stale fails in the job system), then sort by status (succeeded is priority), then by time (newest first). The 'best' cached result is returned, by letting the user instead know about the existing ID, rather than a new item.
+Jobs are cached in the following way. When you request to create a job, the payload and type are hashed. Job(s) in the system may exist with this hash - these are retrieved. If no matching hashes, then the new job is created and cached is false in the response. If there are matches, we first disregard failed jobs (so we aren't hitting stale fails in the job system), then sort by status (succeeded is priority), then by time (newest first). The 'best' cached result is returned, by letting the user instead know about the existing ID, rather than a new item.
 
 This request is still logged as a JobRequest, however no new Job is created.
 

--- a/packages/web-api/jest.config.js
+++ b/packages/web-api/jest.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
   setupFiles: ['dotenv/config']
 };


### PR DESCRIPTION
Improves job system cache by 

- sorting and filtering to remove failed tasks
- adding documentation

I could not understand how to replicate https://github.com/orgs/open-AIMS/projects/11/views/2?pane=issue&itemId=112007946 . 

We need to separate concerns here 

1. invalidating cache based on additional information such as worker version or dataset inputs
2. ensuring that db-reset results in a cleared cache

1) is a separate issue and out of scope here
2) I cannot replicate this nor understand how it could be happening. Unless db-reset didn't actually delete the data? If a job is created, the assignment storage path is made unique by using Date.now() as part of the file path, so there is no way you could hit an old storage location anyway, as long as a new job was made.

