### PR TITLE
restore the gold color raster

### DIFF
--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -40,7 +40,7 @@ import {
 import { WebApiService } from '../../api/web-api.service';
 import { environment } from '../../environments/environment';
 import { getFirstFileFromResults } from '../../util/api-util';
-import { ColorRGBA } from '../../util/arcgis/arcgis-layer-util';
+import { ColorRGBA, createSingleColorRasterFunction } from '../../util/arcgis/arcgis-layer-util';
 import { seperateHttpParams, urlToBlobObjectURL } from '../../util/http-util';
 import { isDefined } from '../../util/js-util';
 import { AuthService } from '../auth/auth.service';
@@ -555,10 +555,11 @@ export class ReefGuideMapService {
       title: region.region,
       url: cleanUrl,
       customParameters: params,
-      opacity: 0.9
+      opacity: 0.9,
       // gold color
-      // this breaks new COG, TODO heatmap in OpenLayers
-      //rasterFunction: createSingleColorRasterFunction(this.assessColor),
+      // Note: this only works with binary color COG, it broke with the greyscale raster.
+      // TODO heatmap in OpenLayers
+      rasterFunction: createSingleColorRasterFunction(this.assessColor),
     });
     groupLayer.add(layer);
   }

--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -559,7 +559,7 @@ export class ReefGuideMapService {
       // gold color
       // Note: this only works with binary color COG, it broke with the greyscale raster.
       // TODO heatmap in OpenLayers
-      rasterFunction: createSingleColorRasterFunction(this.assessColor),
+      rasterFunction: createSingleColorRasterFunction(this.assessColor)
     });
     groupLayer.add(layer);
   }


### PR DESCRIPTION
Restore the ArcGIS map `rasterFunction` that shows COG in gold color.
closes https://github.com/open-AIMS/MADAME-app/issues/29

This broke when we were trying greyscale COGs. For some reason this only works with binary color. ArcGIS specific, so not worthing investigating.

## Known Issues

Color styling no longer works, not worth looking into until OpenLayers migration done. Opacity works though.
