### PR TITLE
feat: backend persistence and list view for projects

### DIFF
--- a/format-lint.sh
+++ b/format-lint.sh
@@ -1,0 +1,1 @@
+turbo format:write --force && turbo fix --force && turbo lint --force

--- a/packages/app/src/api/web-api.service.ts
+++ b/packages/app/src/api/web-api.service.ts
@@ -3,13 +3,20 @@ import { inject, Injectable } from '@angular/core';
 import { JobType, Polygon, PolygonNote, User, UserRole } from '@reefguide/db';
 import {
   CreateJobResponse,
+  CreateProjectInput,
+  CreateProjectResponse,
+  DeleteProjectResponse,
   DownloadResponse,
+  GetProjectResponse,
+  GetProjectsResponse,
   JobDetailsResponse,
   ListJobsQuery,
   ListJobsResponse,
   ListUserLogsResponse,
   LoginResponse,
-  ProfileResponse
+  ProfileResponse,
+  UpdateProjectInput,
+  UpdateProjectResponse
 } from '@reefguide/types';
 import {
   distinctUntilKeyChanged,
@@ -230,5 +237,36 @@ export class WebApiService {
         );
       })
     );
+  }
+
+  getProjects(query?: {
+    type?: string;
+    name?: string;
+    limit?: number;
+    offset?: number;
+  }): Observable<GetProjectsResponse> {
+    return this.http.get<GetProjectsResponse>(`${this.base}/projects`, {
+      params: query as any
+    });
+  }
+
+  getProject(id: number): Observable<GetProjectResponse> {
+    return this.http.get<GetProjectResponse>(`${this.base}/projects/${id}`);
+  }
+
+  createProject(projectData: CreateProjectInput): Observable<CreateProjectResponse> {
+    return this.http.post<CreateProjectResponse>(`${this.base}/projects`, projectData);
+  }
+
+  updateProject(id: number, projectData: UpdateProjectInput): Observable<UpdateProjectResponse> {
+    return this.http.put<UpdateProjectResponse>(`${this.base}/projects/${id}`, projectData);
+  }
+
+  deleteProject(id: number): Observable<DeleteProjectResponse> {
+    return this.http.delete<DeleteProjectResponse>(`${this.base}/projects/${id}`);
+  }
+
+  getUserProjects(): Observable<GetProjectsResponse> {
+    return this.http.get<GetProjectsResponse>(`${this.base}/projects/user/me`);
   }
 }

--- a/packages/app/src/app/app.routes.ts
+++ b/packages/app/src/app/app.routes.ts
@@ -3,12 +3,12 @@ import { Routes } from '@angular/router';
 import { JobsTableComponent } from './jobs/jobs-table/jobs-table.component';
 
 export const routes: Routes = [
-  //{
-  //  path: '',
-  //  loadComponent: () =>
-  //    import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
-  //  title: 'My Projects'
-  //},
+  {
+    path: '',
+    loadComponent: () =>
+      import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
+    title: 'My Projects'
+  },
   //{
   //  path: 'projects',
   //  loadComponent: () =>

--- a/packages/app/src/app/app.routes.ts
+++ b/packages/app/src/app/app.routes.ts
@@ -5,24 +5,14 @@ import { JobsTableComponent } from './jobs/jobs-table/jobs-table.component';
 export const routes: Routes = [
   {
     path: '',
+    pathMatch: 'full',
+    redirectTo: 'projects'
+  },
+  {
+    path: 'projects',
     loadComponent: () =>
       import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
     title: 'My Projects'
-  },
-  //{
-  //  path: 'projects',
-  //  loadComponent: () =>
-  //    import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
-  //  title: 'My Projects'
-  //},
-  {
-    path: 'test',
-    loadComponent: () =>
-      import('./model-workflow/model-workflow.component').then(m => {
-        console.log('Hit');
-        return m.ModelWorkflowComponent;
-      }),
-    title: 'ADRIA Model Run'
   },
   {
     path: 'adria/:projectId',
@@ -31,18 +21,13 @@ export const routes: Routes = [
     title: 'ADRIA Model Run'
   },
   {
-    path: 'location-selection',
+    path: 'location-selection/:projectId',
     loadComponent: () =>
       import('./location-selection/location-selection.component').then(m => {
         console.log('selection');
         return m.LocationSelectionComponent;
       }),
     title: 'Location Selection'
-  },
-  {
-    path: 'test-map',
-    loadComponent: () => import('./test/test-map/test-map.component').then(m => m.TestMapComponent),
-    title: 'Test Map'
   },
   {
     path: 'jobs',

--- a/packages/app/src/app/app.routes.ts
+++ b/packages/app/src/app/app.routes.ts
@@ -3,23 +3,40 @@ import { Routes } from '@angular/router';
 import { JobsTableComponent } from './jobs/jobs-table/jobs-table.component';
 
 export const routes: Routes = [
+  //{
+  //  path: '',
+  //  loadComponent: () =>
+  //    import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
+  //  title: 'My Projects'
+  //},
+  //{
+  //  path: 'projects',
+  //  loadComponent: () =>
+  //    import('./projects/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
+  //  title: 'My Projects'
+  //},
   {
-    path: '',
-    redirectTo: '/location-selection',
-    pathMatch: 'full'
+    path: 'test',
+    loadComponent: () =>
+      import('./model-workflow/model-workflow.component').then(m => {
+        console.log('Hit');
+        return m.ModelWorkflowComponent;
+      }),
+    title: 'ADRIA Model Run'
   },
   {
-    path: 'new-run',
+    path: 'adria/:projectId',
     loadComponent: () =>
       import('./model-workflow/model-workflow.component').then(m => m.ModelWorkflowComponent),
-    title: 'Model run manager'
+    title: 'ADRIA Model Run'
   },
   {
     path: 'location-selection',
     loadComponent: () =>
-      import('./location-selection/location-selection.component').then(
-        m => m.LocationSelectionComponent
-      ),
+      import('./location-selection/location-selection.component').then(m => {
+        console.log('selection');
+        return m.LocationSelectionComponent;
+      }),
     title: 'Location Selection'
   },
   {
@@ -27,23 +44,6 @@ export const routes: Routes = [
     loadComponent: () => import('./test/test-map/test-map.component').then(m => m.TestMapComponent),
     title: 'Test Map'
   },
-  // Legacy routes - redirect to new workflow
-  {
-    path: 'invoke-run',
-    redirectTo: '/new-run',
-    pathMatch: 'full'
-  },
-  {
-    path: 'view-run/:id',
-    redirectTo: '/new-run',
-    pathMatch: 'full'
-  },
-  {
-    path: 'runs',
-    redirectTo: '/new-run',
-    pathMatch: 'full'
-  },
-  // initial work on jobs list page. should have auth guard.
   {
     path: 'jobs',
     component: JobsTableComponent,

--- a/packages/app/src/app/model-workflow/model-workflow.component.html
+++ b/packages/app/src/app/model-workflow/model-workflow.component.html
@@ -2,6 +2,16 @@
 <div class="workflow-container">
   <!-- Tab Header with Controls -->
   <div class="workspace-header">
+    <!-- Back to Projects Button -->
+    <button
+      mat-icon-button
+      class="back-button"
+      matTooltip="Back to projects"
+      (click)="navigateToProjects()"
+    >
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+
     <mat-tab-group
       class="workspace-tabs"
       [selectedIndex]="selectedTabIndex()"

--- a/packages/app/src/app/model-workflow/model-workflow.component.html
+++ b/packages/app/src/app/model-workflow/model-workflow.component.html
@@ -149,9 +149,7 @@
               <mat-icon class="instructions-icon">science</mat-icon>
               <p>
                 Configure your model parameters
-                {{
-                  parameterPanelCollapsed() ? 'by showing the parameter panel' : 'on the left'
-                }}
+                {{ parameterPanelCollapsed() ? 'by showing the parameter panel' : 'on the left' }}
                 and click Submit to start your simulation.
               </p>
             </div>

--- a/packages/app/src/app/model-workflow/model-workflow.component.html
+++ b/packages/app/src/app/model-workflow/model-workflow.component.html
@@ -62,7 +62,8 @@
         <button
           mat-menu-item
           (click)="copyParametersToNewWorkspace(workspace.id)"
-          [disabled]="!workspace.parameters">
+          [disabled]="!workspace.parameters"
+        >
           <mat-icon>content_copy</mat-icon>
           <span>Copy parameters to new workspace</span>
         </button>
@@ -147,8 +148,11 @@
             <div class="instructions-content">
               <mat-icon class="instructions-icon">science</mat-icon>
               <p>
-                Configure your model parameters {{ parameterPanelCollapsed() ? 'by showing the parameter panel' : 'on the left' }} and click Submit to start your
-                simulation.
+                Configure your model parameters
+                {{
+                  parameterPanelCollapsed() ? 'by showing the parameter panel' : 'on the left'
+                }}
+                and click Submit to start your simulation.
               </p>
             </div>
           </mat-card-content>

--- a/packages/app/src/app/model-workflow/model-workflow.component.scss
+++ b/packages/app/src/app/model-workflow/model-workflow.component.scss
@@ -295,7 +295,9 @@
   overflow: hidden;
   background: white;
   border-right: 1px solid #e0e0e0;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease;
 
   &.collapsed {
     opacity: 0;
@@ -316,7 +318,9 @@
   cursor: col-resize;
   position: relative;
   border-right: 1px solid #e0e0e0;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease;
   user-select: none;
 
   &:hover {

--- a/packages/app/src/app/model-workflow/model-workflow.component.ts
+++ b/packages/app/src/app/model-workflow/model-workflow.component.ts
@@ -1,41 +1,27 @@
 // src/app/model-workflow/model-workflow.component.ts
+import { Component, computed, inject, signal, effect, HostListener, ElementRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {
-  Component,
-  computed,
-  effect,
-  ElementRef,
-  HostListener,
-  inject,
-  OnInit,
-  signal
-} from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatTabsModule } from '@angular/material/tabs';
+import { Router } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { ActivatedRoute, Router } from '@angular/router';
-import { Project } from '@reefguide/db';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { JobDetailsResponse } from '@reefguide/types';
 import { WebApiService } from '../../api/web-api.service';
 import { JobStatusComponent } from '../jobs/job-status/job-status.component';
 import { JobStatusConfig, mergeJobConfig } from '../jobs/job-status/job-status.types';
 import {
-  ModelParameters,
-  ParameterConfigComponent
+  ParameterConfigComponent,
+  ModelParameters
 } from './parameter-config/parameter-config.component';
 import { ResultsViewComponent } from './results-view/results-view.component';
-import {
-  WorkspacePersistenceService,
-  WorkspaceState
-} from './services/workspace-persistence.service';
-import { toPersistedWorkspace, toRuntimeWorkspace } from './services/workspace-persistence.types';
 import { WorkspaceNameDialogComponent } from './workspace-name-dialog/workspace-name-dialog.component';
+import { WorkspacePersistenceService, WorkspaceState } from './services/workspace-persistence.service';
+import { toPersistedWorkspace, toRuntimeWorkspace, RuntimeWorkspace } from './services/workspace-persistence.types';
 
 type WorkflowState = 'configuring' | 'submitting' | 'monitoring' | 'viewing';
 
@@ -156,21 +142,17 @@ class WorkspaceService {
   templateUrl: './model-workflow.component.html',
   styleUrl: './model-workflow.component.scss'
 })
-export class ModelWorkflowComponent implements OnInit {
+export class ModelWorkflowComponent {
   private readonly api = inject(WebApiService);
   private readonly router = inject(Router);
-  private readonly route = inject(ActivatedRoute);
   private readonly dialog = inject(MatDialog);
-  private readonly snackBar = inject(MatSnackBar);
   private readonly persistenceService = inject(WorkspacePersistenceService);
   private readonly elementRef = inject(ElementRef);
 
-  // Project and workspace management
-  private currentProject = signal<Project | null>(null);
+  // Workspace management
   private workspaceCounter = signal(0);
   private workspaces = signal<Workspace[]>([]);
   private activeWorkspaceId = signal<string | null>(null);
-  private isLoading = signal(true);
 
   // Panel state management
   public parameterPanelCollapsed = signal(false);
@@ -197,15 +179,18 @@ export class ModelWorkflowComponent implements OnInit {
   });
 
   constructor() {
-    // Set up auto-save effect - save to project_state whenever workspaces change
+    // Try to restore from persistence first
+    this.loadWorkspacesFromPersistence();
+
+    // Set up auto-save effect
     effect(() => {
       const workspaces = this.workspaces();
       const activeId = this.activeWorkspaceId();
       const counter = this.workspaceCounter();
 
-      // Only save if we have workspaces and a project loaded
-      if (workspaces.length > 0 && this.currentProject() && !this.isLoading()) {
-        this.saveWorkspacesToProject();
+      // Only save if we have workspaces (avoid saving empty state during initialization)
+      if (workspaces.length > 0) {
+        this.saveWorkspacesToPersistence();
       }
     });
 
@@ -215,132 +200,6 @@ export class ModelWorkflowComponent implements OnInit {
       const element = this.elementRef.nativeElement as HTMLElement;
       element.style.setProperty('--left-panel-width', `${width}px`);
     });
-  }
-
-  ngOnInit(): void {
-    // Check for project ID in route
-    const projectIdParam = this.route.snapshot.paramMap.get('projectId');
-
-    if (projectIdParam) {
-      const projectId = parseInt(projectIdParam, 10);
-      if (isNaN(projectId)) {
-        this.handleError('Invalid project ID');
-        return;
-      }
-      this.loadExistingProject(projectId);
-    } else {
-      // No project ID, create new project
-      this.createNewProject();
-    }
-  }
-
-  // Load existing project and its workspaces from project_state
-  private loadExistingProject(projectId: number): void {
-    this.isLoading.set(true);
-
-    this.persistenceService.loadProject(projectId).subscribe({
-      next: project => {
-        this.currentProject.set(project);
-        this.loadWorkspacesFromProject();
-      },
-      error: error => {
-        console.error('Failed to load project:', error);
-        this.handleError('Failed to load project');
-      }
-    });
-  }
-
-  // Create a new project
-  private createNewProject(): void {
-    const projectName = `Coral Reef Analysis ${new Date().toLocaleDateString()}`;
-
-    this.persistenceService.createProject(projectName, 'Coral reef simulation project').subscribe({
-      next: project => {
-        this.currentProject.set(project);
-        // Update URL to include project ID
-        this.router.navigate(['/projects', project.id, 'adria'], { replaceUrl: true });
-        this.createDefaultWorkspace();
-        this.isLoading.set(false);
-      },
-      error: error => {
-        console.error('Failed to create project:', error);
-        this.handleError('Failed to create project');
-      }
-    });
-  }
-
-  // Load workspaces from the current project's project_state
-  private loadWorkspacesFromProject(): void {
-    this.persistenceService.loadWorkspaceState().subscribe({
-      next: savedState => {
-        if (savedState && savedState.workspaces.length > 0) {
-          // Restore from saved state
-          this.workspaceCounter.set(savedState.workspaceCounter);
-
-          const runtimeWorkspaces = savedState.workspaces.map(pw => toRuntimeWorkspace(pw));
-          this.workspaces.set(runtimeWorkspaces);
-
-          // Restore active workspace (with fallback)
-          const activeId =
-            savedState.activeWorkspaceId &&
-            runtimeWorkspaces.find(w => w.id === savedState.activeWorkspaceId)
-              ? savedState.activeWorkspaceId
-              : runtimeWorkspaces[0].id;
-
-          this.activeWorkspaceId.set(activeId);
-
-          // Initialize services for restored workspaces
-          runtimeWorkspaces.forEach(workspace => {
-            this.getWorkspaceService(workspace.id);
-          });
-
-          console.log(`Restored ${runtimeWorkspaces.length} workspaces from project`);
-        } else {
-          // No saved state, create default workspace
-          this.createDefaultWorkspace();
-        }
-        this.isLoading.set(false);
-      },
-      error: error => {
-        console.error('Failed to load workspace state:', error);
-        this.createDefaultWorkspace();
-        this.isLoading.set(false);
-      }
-    });
-  }
-
-  // Create default workspace
-  private createDefaultWorkspace(): void {
-    this.createWorkspaceWithName('Workspace 1');
-  }
-
-  // Save all workspaces to the project's project_state field
-  private saveWorkspacesToProject(): void {
-    if (!this.persistenceService.isProjectAvailable()) {
-      return;
-    }
-
-    const workspaces = this.workspaces();
-    const persistedWorkspaces = workspaces.map(w => toPersistedWorkspace(w));
-
-    const state: WorkspaceState = {
-      workspaces: persistedWorkspaces,
-      activeWorkspaceId: this.activeWorkspaceId(),
-      workspaceCounter: this.workspaceCounter()
-    };
-
-    this.persistenceService.saveWorkspaceState(state).subscribe({
-      error: error => {
-        console.error('Failed to save workspace state:', error);
-        this.snackBar.open('Failed to save workspace state', 'Dismiss', { duration: 3000 });
-      }
-    });
-  }
-
-  // Handle errors
-  private handleError(message: string): void {
-    this.snackBar.open(message, 'Dismiss', { duration: 5000 });
-    this.router.navigate(['/projects']);
   }
 
   // Panel management methods
@@ -375,6 +234,61 @@ export class ModelWorkflowComponent implements OnInit {
 
     this.isDragging.set(false);
     document.body.classList.remove('dragging-active');
+  }
+
+  // Load workspaces from persistence
+  private loadWorkspacesFromPersistence(): void {
+    if (!this.persistenceService.isStorageAvailable()) {
+      console.warn('Local storage not available, creating default workspace');
+      this.createWorkspaceWithName('Workspace 1');
+      return;
+    }
+
+    const savedState = this.persistenceService.loadWorkspaceState();
+
+    if (savedState && savedState.workspaces.length > 0) {
+      // Restore from saved state
+      this.workspaceCounter.set(savedState.workspaceCounter);
+
+      const runtimeWorkspaces = savedState.workspaces.map(pw => toRuntimeWorkspace(pw));
+      this.workspaces.set(runtimeWorkspaces);
+
+      // Restore active workspace (with fallback)
+      const activeId = savedState.activeWorkspaceId &&
+        runtimeWorkspaces.find(w => w.id === savedState.activeWorkspaceId)
+        ? savedState.activeWorkspaceId
+        : runtimeWorkspaces[0].id;
+
+      this.activeWorkspaceId.set(activeId);
+
+      // Initialize services for restored workspaces
+      runtimeWorkspaces.forEach(workspace => {
+        this.getWorkspaceService(workspace.id);
+      });
+
+      console.log(`Restored ${runtimeWorkspaces.length} workspaces from storage`);
+    } else {
+      // No saved state, create default workspace
+      this.createWorkspaceWithName('Workspace 1');
+    }
+  }
+
+  // Save workspaces to persistence
+  private saveWorkspacesToPersistence(): void {
+    if (!this.persistenceService.isStorageAvailable()) {
+      return;
+    }
+
+    const workspaces = this.workspaces();
+    const persistedWorkspaces = workspaces.map(w => toPersistedWorkspace(w));
+
+    const state: WorkspaceState = {
+      workspaces: persistedWorkspaces,
+      activeWorkspaceId: this.activeWorkspaceId(),
+      workspaceCounter: this.workspaceCounter()
+    };
+
+    this.persistenceService.saveWorkspaceState(state);
   }
 
   getWorkspaceService(workspaceId: string): WorkspaceService | null {

--- a/packages/app/src/app/model-workflow/model-workflow.component.ts
+++ b/packages/app/src/app/model-workflow/model-workflow.component.ts
@@ -1,5 +1,15 @@
 // src/app/model-workflow/model-workflow.component.ts
-import { Component, computed, inject, signal, effect, HostListener, ElementRef, OnInit, OnDestroy } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  effect,
+  HostListener,
+  ElementRef,
+  OnInit,
+  OnDestroy
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -21,8 +31,15 @@ import {
 } from './parameter-config/parameter-config.component';
 import { ResultsViewComponent } from './results-view/results-view.component';
 import { WorkspaceNameDialogComponent } from './workspace-name-dialog/workspace-name-dialog.component';
-import { WorkspacePersistenceService, WorkspaceState } from './services/workspace-persistence.service';
-import { toPersistedWorkspace, toRuntimeWorkspace, RuntimeWorkspace } from './services/workspace-persistence.types';
+import {
+  WorkspacePersistenceService,
+  WorkspaceState
+} from './services/workspace-persistence.service';
+import {
+  toPersistedWorkspace,
+  toRuntimeWorkspace,
+  RuntimeWorkspace
+} from './services/workspace-persistence.types';
 
 type WorkflowState = 'configuring' | 'submitting' | 'monitoring' | 'viewing';
 
@@ -197,29 +214,31 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     // Extract project ID from route and initialize workspace state
-    this.route.params.pipe(
-      takeUntil(this.destroy$),
-      tap(params => {
-        const projectId = params['projectId'] ? parseInt(params['projectId'], 10) : null;
-        this.projectId.set(projectId);
+    this.route.params
+      .pipe(
+        takeUntil(this.destroy$),
+        tap(params => {
+          const projectId = params['projectId'] ? parseInt(params['projectId'], 10) : null;
+          this.projectId.set(projectId);
 
-        if (projectId) {
-          this.persistenceService.setProjectId(projectId);
+          if (projectId) {
+            this.persistenceService.setProjectId(projectId);
+          }
+        }),
+        switchMap(() => this.loadWorkspacesFromPersistence())
+      )
+      .subscribe({
+        next: () => {
+          this.isLoading.set(false);
+          console.log('Workspace initialization complete');
+        },
+        error: error => {
+          console.error('Failed to initialize workspaces:', error);
+          this.isLoading.set(false);
+          // Create default workspace as fallback
+          this.createWorkspaceWithName('Workspace 1');
         }
-      }),
-      switchMap(() => this.loadWorkspacesFromPersistence())
-    ).subscribe({
-      next: () => {
-        this.isLoading.set(false);
-        console.log('Workspace initialization complete');
-      },
-      error: (error) => {
-        console.error('Failed to initialize workspaces:', error);
-        this.isLoading.set(false);
-        // Create default workspace as fallback
-        this.createWorkspaceWithName('Workspace 1');
-      }
-    });
+      });
   }
 
   ngOnDestroy(): void {
@@ -278,10 +297,11 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
           this.workspaces.set(runtimeWorkspaces);
 
           // Restore active workspace (with fallback)
-          const activeId = savedState.activeWorkspaceId &&
+          const activeId =
+            savedState.activeWorkspaceId &&
             runtimeWorkspaces.find(w => w.id === savedState.activeWorkspaceId)
-            ? savedState.activeWorkspaceId
-            : runtimeWorkspaces[0].id;
+              ? savedState.activeWorkspaceId
+              : runtimeWorkspaces[0].id;
 
           this.activeWorkspaceId.set(activeId);
 
@@ -317,16 +337,17 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
         workspaceCounter: this.workspaceCounter()
       };
 
-      this.persistenceService.saveWorkspaceState(state).pipe(
-        takeUntil(this.destroy$)
-      ).subscribe({
-        next: () => {
-          console.log('Workspace state saved successfully');
-        },
-        error: (error) => {
-          console.warn('Failed to save workspace state:', error);
-        }
-      });
+      this.persistenceService
+        .saveWorkspaceState(state)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: () => {
+            console.log('Workspace state saved successfully');
+          },
+          error: error => {
+            console.warn('Failed to save workspace state:', error);
+          }
+        });
     }, 500); // 500ms debounce
   }
 

--- a/packages/app/src/app/model-workflow/model-workflow.component.ts
+++ b/packages/app/src/app/model-workflow/model-workflow.component.ts
@@ -1,15 +1,5 @@
 // src/app/model-workflow/model-workflow.component.ts
-import {
-  Component,
-  computed,
-  inject,
-  signal,
-  effect,
-  HostListener,
-  ElementRef,
-  OnInit,
-  OnDestroy
-} from '@angular/core';
+import { Component, computed, inject, signal, effect, HostListener, ElementRef, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -31,15 +21,8 @@ import {
 } from './parameter-config/parameter-config.component';
 import { ResultsViewComponent } from './results-view/results-view.component';
 import { WorkspaceNameDialogComponent } from './workspace-name-dialog/workspace-name-dialog.component';
-import {
-  WorkspacePersistenceService,
-  WorkspaceState
-} from './services/workspace-persistence.service';
-import {
-  toPersistedWorkspace,
-  toRuntimeWorkspace,
-  RuntimeWorkspace
-} from './services/workspace-persistence.types';
+import { WorkspacePersistenceService, WorkspaceState } from './services/workspace-persistence.service';
+import { toPersistedWorkspace, toRuntimeWorkspace, RuntimeWorkspace } from './services/workspace-persistence.types';
 
 type WorkflowState = 'configuring' | 'submitting' | 'monitoring' | 'viewing';
 
@@ -214,31 +197,29 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     // Extract project ID from route and initialize workspace state
-    this.route.params
-      .pipe(
-        takeUntil(this.destroy$),
-        tap(params => {
-          const projectId = params['projectId'] ? parseInt(params['projectId'], 10) : null;
-          this.projectId.set(projectId);
+    this.route.params.pipe(
+      takeUntil(this.destroy$),
+      tap(params => {
+        const projectId = params['projectId'] ? parseInt(params['projectId'], 10) : null;
+        this.projectId.set(projectId);
 
-          if (projectId) {
-            this.persistenceService.setProjectId(projectId);
-          }
-        }),
-        switchMap(() => this.loadWorkspacesFromPersistence())
-      )
-      .subscribe({
-        next: () => {
-          this.isLoading.set(false);
-          console.log('Workspace initialization complete');
-        },
-        error: error => {
-          console.error('Failed to initialize workspaces:', error);
-          this.isLoading.set(false);
-          // Create default workspace as fallback
-          this.createWorkspaceWithName('Workspace 1');
+        if (projectId) {
+          this.persistenceService.setProjectId(projectId);
         }
-      });
+      }),
+      switchMap(() => this.loadWorkspacesFromPersistence())
+    ).subscribe({
+      next: () => {
+        this.isLoading.set(false);
+        console.log('Workspace initialization complete');
+      },
+      error: (error) => {
+        console.error('Failed to initialize workspaces:', error);
+        this.isLoading.set(false);
+        // Create default workspace as fallback
+        this.createWorkspaceWithName('Workspace 1');
+      }
+    });
   }
 
   ngOnDestroy(): void {
@@ -297,11 +278,10 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
           this.workspaces.set(runtimeWorkspaces);
 
           // Restore active workspace (with fallback)
-          const activeId =
-            savedState.activeWorkspaceId &&
+          const activeId = savedState.activeWorkspaceId &&
             runtimeWorkspaces.find(w => w.id === savedState.activeWorkspaceId)
-              ? savedState.activeWorkspaceId
-              : runtimeWorkspaces[0].id;
+            ? savedState.activeWorkspaceId
+            : runtimeWorkspaces[0].id;
 
           this.activeWorkspaceId.set(activeId);
 
@@ -337,17 +317,16 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
         workspaceCounter: this.workspaceCounter()
       };
 
-      this.persistenceService
-        .saveWorkspaceState(state)
-        .pipe(takeUntil(this.destroy$))
-        .subscribe({
-          next: () => {
-            console.log('Workspace state saved successfully');
-          },
-          error: error => {
-            console.warn('Failed to save workspace state:', error);
-          }
-        });
+      this.persistenceService.saveWorkspaceState(state).pipe(
+        takeUntil(this.destroy$)
+      ).subscribe({
+        next: () => {
+          console.log('Workspace state saved successfully');
+        },
+        error: (error) => {
+          console.warn('Failed to save workspace state:', error);
+        }
+      });
     }, 500); // 500ms debounce
   }
 
@@ -688,9 +667,9 @@ export class ModelWorkflowComponent implements OnInit, OnDestroy {
     return workspace.id;
   }
 
-  // Navigate back to run list
-  navigateToRunList(): void {
-    this.router.navigate(['/runs']);
+  // Navigate back to projects list
+  navigateToProjects(): void {
+    this.router.navigate(['/projects']);
   }
 
   // Get default job config as fallback

--- a/packages/app/src/app/model-workflow/parameter-config/parameter-config.component.ts
+++ b/packages/app/src/app/model-workflow/parameter-config/parameter-config.component.ts
@@ -411,7 +411,7 @@ export class ParameterConfigComponent {
         }),
         debounceTime(500), // Debounce only the auto-save, not the UI updates
         distinctUntilChanged((prev, curr) => {
-          console.log("Debounced param check")
+          console.log('Debounced param check');
           // Only emit if form values actually changed (deep comparison)
           return JSON.stringify(prev) === JSON.stringify(curr);
         })

--- a/packages/app/src/app/model-workflow/services/workspace-persistence.service.ts
+++ b/packages/app/src/app/model-workflow/services/workspace-persistence.service.ts
@@ -108,9 +108,8 @@ export class WorkspacePersistenceService {
 
         // Update active workspace if it was removed
         if (currentState.activeWorkspaceId === workspaceId) {
-          currentState.activeWorkspaceId = currentState.workspaces.length > 0
-            ? currentState.workspaces[0].id
-            : null;
+          currentState.activeWorkspaceId =
+            currentState.workspaces.length > 0 ? currentState.workspaces[0].id : null;
         }
 
         return currentState;
@@ -167,16 +166,18 @@ export class WorkspacePersistenceService {
       workspaces: state
     };
 
-    return this.api.updateProject(this.projectId, {
-      project_state: projectState
-    }).pipe(
-      map(() => void 0),
-      catchError(error => {
-        console.warn('Failed to save workspace state to backend:', error);
-        // Fallback to localStorage
-        return this.saveToLocalStorage(state);
+    return this.api
+      .updateProject(this.projectId, {
+        project_state: projectState
       })
-    );
+      .pipe(
+        map(() => void 0),
+        catchError(error => {
+          console.warn('Failed to save workspace state to backend:', error);
+          // Fallback to localStorage
+          return this.saveToLocalStorage(state);
+        })
+      );
   }
 
   private loadFromBackend(): Observable<WorkspaceState | null> {
@@ -215,16 +216,18 @@ export class WorkspacePersistenceService {
       return throwError(() => new Error('Project ID not set'));
     }
 
-    return this.api.updateProject(this.projectId, {
-      project_state: {}
-    }).pipe(
-      map(() => void 0),
-      catchError(error => {
-        console.warn('Failed to clear workspace state from backend:', error);
-        // Fallback to localStorage
-        return this.clearFromLocalStorage();
+    return this.api
+      .updateProject(this.projectId, {
+        project_state: {}
       })
-    );
+      .pipe(
+        map(() => void 0),
+        catchError(error => {
+          console.warn('Failed to clear workspace state from backend:', error);
+          // Fallback to localStorage
+          return this.clearFromLocalStorage();
+        })
+      );
   }
 
   // ==================

--- a/packages/app/src/app/model-workflow/services/workspace-persistence.service.ts
+++ b/packages/app/src/app/model-workflow/services/workspace-persistence.service.ts
@@ -1,6 +1,9 @@
 // src/app/model-workflow/services/workspace-persistence.service.ts
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
+import { map, catchError, tap, switchMap } from 'rxjs/operators';
 import { ModelParameters } from '../parameter-config/parameter-config.component';
+import { WebApiService } from '../../../api/web-api.service';
 
 export interface PersistedWorkspace {
   id: string;
@@ -20,99 +23,123 @@ export interface WorkspaceState {
   providedIn: 'root'
 })
 export class WorkspacePersistenceService {
+  private readonly api = inject(WebApiService);
+
   private readonly STORAGE_KEY = 'reef-guide-workspaces';
   private readonly VERSION = '1.0';
   private readonly VERSION_KEY = 'reef-guide-workspaces-version';
+
+  private projectId: number | null = null;
 
   constructor() {
     this.migrateIfNeeded();
   }
 
+  // Set the project ID for persistence operations
+  setProjectId(projectId: number): void {
+    this.projectId = projectId;
+  }
+
+  // Get current project ID
+  getProjectId(): number | null {
+    return this.projectId;
+  }
+
   // Save complete workspace state
-  saveWorkspaceState(state: WorkspaceState): void {
-    try {
-      const serializedState = JSON.stringify(state);
-      localStorage.setItem(this.STORAGE_KEY, serializedState);
-      localStorage.setItem(this.VERSION_KEY, this.VERSION);
-    } catch (error) {
-      console.warn('Failed to save workspace state:', error);
+  saveWorkspaceState(state: WorkspaceState): Observable<void> {
+    // If we have a project ID, save to backend; otherwise use localStorage
+    if (this.projectId) {
+      return this.saveToBackend(state);
+    } else {
+      return this.saveToLocalStorage(state);
     }
   }
 
   // Load complete workspace state
-  loadWorkspaceState(): WorkspaceState | null {
-    try {
-      const serializedState = localStorage.getItem(this.STORAGE_KEY);
-      if (!serializedState) {
-        return null;
-      }
-
-      const state: WorkspaceState = JSON.parse(serializedState);
-
-      // Validate the loaded state
-      if (!this.isValidWorkspaceState(state)) {
-        console.warn('Invalid workspace state found, clearing storage');
-        this.clearWorkspaceState();
-        return null;
-      }
-
-      return state;
-    } catch (error) {
-      console.warn('Failed to load workspace state:', error);
-      this.clearWorkspaceState();
-      return null;
+  loadWorkspaceState(): Observable<WorkspaceState | null> {
+    // If we have a project ID, load from backend; otherwise use localStorage
+    if (this.projectId) {
+      return this.loadFromBackend();
+    } else {
+      return this.loadFromLocalStorage();
     }
   }
 
   // Clear all workspace state
-  clearWorkspaceState(): void {
-    try {
-      localStorage.removeItem(this.STORAGE_KEY);
-      localStorage.removeItem(this.VERSION_KEY);
-    } catch (error) {
-      console.warn('Failed to clear workspace state:', error);
+  clearWorkspaceState(): Observable<void> {
+    if (this.projectId) {
+      return this.clearFromBackend();
+    } else {
+      return this.clearFromLocalStorage();
     }
   }
 
   // Save a single workspace
-  saveWorkspace(workspace: PersistedWorkspace): void {
-    const currentState = this.loadWorkspaceState();
-    if (!currentState) return;
+  saveWorkspace(workspace: PersistedWorkspace): Observable<void> {
+    return this.loadWorkspaceState().pipe(
+      map(currentState => {
+        if (!currentState) return;
 
-    const existingIndex = currentState.workspaces.findIndex(w => w.id === workspace.id);
-    if (existingIndex >= 0) {
-      currentState.workspaces[existingIndex] = workspace;
-    } else {
-      currentState.workspaces.push(workspace);
-    }
+        const existingIndex = currentState.workspaces.findIndex(w => w.id === workspace.id);
+        if (existingIndex >= 0) {
+          currentState.workspaces[existingIndex] = workspace;
+        } else {
+          currentState.workspaces.push(workspace);
+        }
 
-    this.saveWorkspaceState(currentState);
+        return currentState;
+      }),
+      switchMap(updatedState => {
+        if (updatedState) {
+          return this.saveWorkspaceState(updatedState);
+        }
+        return of(void 0);
+      })
+    );
   }
 
   // Remove a workspace
-  removeWorkspace(workspaceId: string): void {
-    const currentState = this.loadWorkspaceState();
-    if (!currentState) return;
+  removeWorkspace(workspaceId: string): Observable<void> {
+    return this.loadWorkspaceState().pipe(
+      map(currentState => {
+        if (!currentState) return null;
 
-    currentState.workspaces = currentState.workspaces.filter(w => w.id !== workspaceId);
+        currentState.workspaces = currentState.workspaces.filter(w => w.id !== workspaceId);
 
-    // Update active workspace if it was removed
-    if (currentState.activeWorkspaceId === workspaceId) {
-      currentState.activeWorkspaceId = currentState.workspaces.length > 0
-        ? currentState.workspaces[0].id
-        : null;
-    }
+        // Update active workspace if it was removed
+        if (currentState.activeWorkspaceId === workspaceId) {
+          currentState.activeWorkspaceId = currentState.workspaces.length > 0
+            ? currentState.workspaces[0].id
+            : null;
+        }
 
-    this.saveWorkspaceState(currentState);
+        return currentState;
+      }),
+      switchMap(updatedState => {
+        if (updatedState) {
+          return this.saveWorkspaceState(updatedState);
+        }
+        return of(void 0);
+      })
+    );
   }
 
   // Update active workspace
-  setActiveWorkspace(workspaceId: string): void {
-    const currentState = this.loadWorkspaceState();
-    if (!currentState) return;
+  setActiveWorkspace(workspaceId: string): Observable<void> {
+    return this.loadWorkspaceState().pipe(
+      map(currentState => {
+        if (!currentState) return null;
 
-    currentState.activeWorkspaceId = workspaceId;
-    this.saveWorkspaceState(currentState);
+        currentState.activeWorkspaceId = workspaceId;
+        return currentState;
+      }),
+      switchMap(updatedState => {
+        if (updatedState) {
+          return this.saveWorkspaceState(updatedState);
+        }
+        return of(void 0);
+      })
+    );
   }
 
   // Check if storage is available
@@ -126,6 +153,142 @@ export class WorkspacePersistenceService {
       return false;
     }
   }
+
+  // ==================
+  // BACKEND PERSISTENCE METHODS
+  // ==================
+
+  private saveToBackend(state: WorkspaceState): Observable<void> {
+    if (!this.projectId) {
+      return throwError(() => new Error('Project ID not set'));
+    }
+
+    const projectState = {
+      workspaces: state
+    };
+
+    return this.api.updateProject(this.projectId, {
+      project_state: projectState
+    }).pipe(
+      map(() => void 0),
+      catchError(error => {
+        console.warn('Failed to save workspace state to backend:', error);
+        // Fallback to localStorage
+        return this.saveToLocalStorage(state);
+      })
+    );
+  }
+
+  private loadFromBackend(): Observable<WorkspaceState | null> {
+    if (!this.projectId) {
+      return throwError(() => new Error('Project ID not set'));
+    }
+
+    return this.api.getProject(this.projectId).pipe(
+      map(response => {
+        const projectState = response.project.project_state as any;
+
+        if (projectState && projectState.workspaces) {
+          const state = projectState.workspaces as WorkspaceState;
+
+          // Validate the loaded state
+          if (!this.isValidWorkspaceState(state)) {
+            console.warn('Invalid workspace state found in project, returning null');
+            return null;
+          }
+
+          return state;
+        }
+
+        return null;
+      }),
+      catchError(error => {
+        console.warn('Failed to load workspace state from backend:', error);
+        // Fallback to localStorage
+        return this.loadFromLocalStorage();
+      })
+    );
+  }
+
+  private clearFromBackend(): Observable<void> {
+    if (!this.projectId) {
+      return throwError(() => new Error('Project ID not set'));
+    }
+
+    return this.api.updateProject(this.projectId, {
+      project_state: {}
+    }).pipe(
+      map(() => void 0),
+      catchError(error => {
+        console.warn('Failed to clear workspace state from backend:', error);
+        // Fallback to localStorage
+        return this.clearFromLocalStorage();
+      })
+    );
+  }
+
+  // ==================
+  // LOCAL STORAGE METHODS (FALLBACK)
+  // ==================
+
+  private saveToLocalStorage(state: WorkspaceState): Observable<void> {
+    try {
+      const serializedState = JSON.stringify(state);
+      localStorage.setItem(this.STORAGE_KEY, serializedState);
+      localStorage.setItem(this.VERSION_KEY, this.VERSION);
+      return of(void 0);
+    } catch (error) {
+      console.warn('Failed to save workspace state to localStorage:', error);
+      return throwError(() => error);
+    }
+  }
+
+  private loadFromLocalStorage(): Observable<WorkspaceState | null> {
+    try {
+      const serializedState = localStorage.getItem(this.STORAGE_KEY);
+      if (!serializedState) {
+        return of(null);
+      }
+
+      const state: WorkspaceState = JSON.parse(serializedState);
+
+      // Validate the loaded state
+      if (!this.isValidWorkspaceState(state)) {
+        console.warn('Invalid workspace state found in localStorage, clearing storage');
+        this.clearFromLocalStorageSync();
+        return of(null);
+      }
+
+      return of(state);
+    } catch (error) {
+      console.warn('Failed to load workspace state from localStorage:', error);
+      this.clearFromLocalStorageSync();
+      return of(null);
+    }
+  }
+
+  private clearFromLocalStorage(): Observable<void> {
+    try {
+      this.clearFromLocalStorageSync();
+      return of(void 0);
+    } catch (error) {
+      console.warn('Failed to clear workspace state from localStorage:', error);
+      return throwError(() => error);
+    }
+  }
+
+  private clearFromLocalStorageSync(): void {
+    try {
+      localStorage.removeItem(this.STORAGE_KEY);
+      localStorage.removeItem(this.VERSION_KEY);
+    } catch (error) {
+      console.warn('Failed to clear workspace state from localStorage:', error);
+    }
+  }
+
+  // ==================
+  // VALIDATION METHODS
+  // ==================
 
   // Validate workspace state structure
   private isValidWorkspaceState(state: any): state is WorkspaceState {
@@ -152,7 +315,7 @@ export class WorkspacePersistenceService {
     );
   }
 
-  // Handle version migrations
+  // Handle version migrations for localStorage
   private migrateIfNeeded(): void {
     const currentVersion = localStorage.getItem(this.VERSION_KEY);
 

--- a/packages/app/src/app/model-workflow/workspace-name-dialog/workspace-name-dialog.component.html
+++ b/packages/app/src/app/model-workflow/workspace-name-dialog/workspace-name-dialog.component.html
@@ -9,17 +9,14 @@
       [(ngModel)]="workspaceName"
       (keyup.enter)="onSave()"
       placeholder="Enter workspace name"
-      #nameInput>
+      #nameInput
+    />
   </mat-form-field>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
   <button mat-button (click)="onCancel()">Cancel</button>
-  <button
-    mat-raised-button
-    color="primary"
-    [disabled]="!workspaceName.trim()"
-    (click)="onSave()">
+  <button mat-raised-button color="primary" [disabled]="!workspaceName.trim()" (click)="onSave()">
     {{ isRename ? 'Rename' : 'Create' }}
   </button>
 </mat-dialog-actions>

--- a/packages/app/src/app/model-workflow/workspace-name-dialog/workspace-name-dialog.component.spec.ts
+++ b/packages/app/src/app/model-workflow/workspace-name-dialog/workspace-name-dialog.component.spec.ts
@@ -9,8 +9,7 @@ describe('WorkspaceNameDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [WorkspaceNameDialogComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(WorkspaceNameDialogComponent);
     component = fixture.componentInstance;

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
@@ -1,11 +1,12 @@
 <form [formGroup]="createForm" (ngSubmit)="onSubmit()">
   <div mat-dialog-title>
     <h2>Create New Project</h2>
-    <p class="dialog-subtitle">Choose a project type and provide basic information to get started.</p>
+    <p class="dialog-subtitle">
+      Choose a project type and provide basic information to get started.
+    </p>
   </div>
 
   <div mat-dialog-content class="dialog-content">
-
     <!-- Project Type Selection -->
     <div class="form-section">
       <h3>Project Type</h3>
@@ -68,22 +69,18 @@
           rows="4"
           maxlength="1000"
         ></textarea>
-        <mat-hint align="end">{{ createForm.get('description')?.value?.length || 0 }}/1000</mat-hint>
+        <mat-hint align="end"
+          >{{ createForm.get('description')?.value?.length || 0 }}/1000</mat-hint
+        >
         <mat-error *ngIf="isFieldInvalid('description')">
           {{ getFieldError('description') }}
         </mat-error>
       </mat-form-field>
     </div>
-
   </div>
 
   <div mat-dialog-actions class="dialog-actions">
-    <button
-      mat-button
-      type="button"
-      (click)="onCancel()"
-      [disabled]="isLoading$ | async"
-    >
+    <button mat-button type="button" (click)="onCancel()" [disabled]="isLoading$ | async">
       Cancel
     </button>
 
@@ -93,11 +90,7 @@
       type="submit"
       [disabled]="createForm.invalid || (isLoading$ | async)"
     >
-      <mat-spinner
-        *ngIf="isLoading$ | async"
-        diameter="20"
-        class="button-spinner"
-      ></mat-spinner>
+      <mat-spinner *ngIf="isLoading$ | async" diameter="20" class="button-spinner"></mat-spinner>
       <span *ngIf="!(isLoading$ | async)">Create Project</span>
       <span *ngIf="isLoading$ | async">Creating...</span>
     </button>

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
@@ -1,0 +1,105 @@
+<form [formGroup]="createForm" (ngSubmit)="onSubmit()">
+  <div mat-dialog-title>
+    <h2>Create New Project</h2>
+    <p class="dialog-subtitle">Choose a project type and provide basic information to get started.</p>
+  </div>
+
+  <div mat-dialog-content class="dialog-content">
+
+    <!-- Project Type Selection -->
+    <div class="form-section">
+      <h3>Project Type</h3>
+      <mat-radio-group formControlName="type" class="project-type-group">
+        <div
+          *ngFor="let projectType of projectTypes"
+          class="project-type-option"
+          [class.selected]="createForm.get('type')?.value === projectType.value"
+        >
+          <mat-radio-button [value]="projectType.value" class="project-type-radio">
+            <div class="project-type-content">
+              <div class="project-type-header">
+                <div class="project-type-icon">
+                  <mat-icon>{{ projectType.icon }}</mat-icon>
+                </div>
+                <div class="project-type-info">
+                  <h4>{{ projectType.label }}</h4>
+                  <p class="project-type-description">
+                    {{ projectType.description }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </mat-radio-button>
+        </div>
+      </mat-radio-group>
+
+      <mat-error *ngIf="isFieldInvalid('type')" class="field-error">
+        {{ getFieldError('type') }}
+      </mat-error>
+    </div>
+
+    <!-- Project Details -->
+    <div class="form-section">
+      <h3>Project Details</h3>
+
+      <!-- Project Name -->
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Project Name</mat-label>
+        <input
+          matInput
+          formControlName="name"
+          placeholder="Enter a descriptive name for your project"
+          maxlength="255"
+          required
+        />
+        <mat-hint align="end">{{ createForm.get('name')?.value?.length || 0 }}/255</mat-hint>
+        <mat-error *ngIf="isFieldInvalid('name')">
+          {{ getFieldError('name') }}
+        </mat-error>
+      </mat-form-field>
+
+      <!-- Project Description -->
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Description (Optional)</mat-label>
+        <textarea
+          matInput
+          formControlName="description"
+          placeholder="Provide additional details about your project goals and scope"
+          rows="4"
+          maxlength="1000"
+        ></textarea>
+        <mat-hint align="end">{{ createForm.get('description')?.value?.length || 0 }}/1000</mat-hint>
+        <mat-error *ngIf="isFieldInvalid('description')">
+          {{ getFieldError('description') }}
+        </mat-error>
+      </mat-form-field>
+    </div>
+
+  </div>
+
+  <div mat-dialog-actions class="dialog-actions">
+    <button
+      mat-button
+      type="button"
+      (click)="onCancel()"
+      [disabled]="isLoading$ | async"
+    >
+      Cancel
+    </button>
+
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="createForm.invalid || (isLoading$ | async)"
+    >
+      <mat-spinner
+        *ngIf="isLoading$ | async"
+        diameter="20"
+        class="button-spinner"
+      ></mat-spinner>
+      <span *ngIf="!(isLoading$ | async)">Create Project</span>
+      <span *ngIf="isLoading$ | async">Creating...</span>
+    </button>
+  </div>
+</form>

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
@@ -1,0 +1,278 @@
+.dialog-subtitle {
+  margin: 8px 0 0 0;
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.875rem;
+  font-weight: 400;
+}
+
+.dialog-content {
+  padding: 24px !important;
+  margin: 0;
+  max-width: none;
+  min-height: 450px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.form-section {
+  margin-bottom: 32px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  h3 {
+    margin: 0 0 20px 0;
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.87);
+    padding-left: 0; // Ensure headings align with content
+  }
+}
+
+.project-type-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.project-type-option {
+  position: relative;
+  border: 2px solid #e0e0e0;
+  border-radius: 12px;
+  transition: all 0.2s ease-in-out;
+  background-color: #fafafa;
+  overflow: hidden;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #1976d2;
+    background-color: #f5f5f5;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  &.selected {
+    border-color: #1976d2;
+    background-color: rgba(25, 118, 210, 0.05);
+    box-shadow: 0 2px 12px rgba(25, 118, 210, 0.2);
+
+    .project-type-content {
+      background-color: transparent;
+    }
+
+    .project-type-icon {
+      background-color: #1976d2;
+
+      mat-icon {
+        color: white;
+      }
+    }
+  }
+}
+
+.project-type-radio {
+  width: 100%;
+  margin: 0;
+
+  ::ng-deep .mat-radio-container {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    z-index: 2;
+  }
+
+  ::ng-deep .mat-radio-outer-circle {
+    border-color: #1976d2;
+    border-width: 2px;
+  }
+
+  ::ng-deep .mat-radio-inner-circle {
+    background-color: #1976d2;
+  }
+
+  ::ng-deep .mat-radio-label {
+    width: 100%;
+    padding: 0;
+    align-items: stretch;
+  }
+
+  ::ng-deep .mat-radio-label-content {
+    width: 100%;
+    padding: 0;
+  }
+}
+
+.project-type-content {
+  padding: 24px;
+  padding-right: 72px; // Increased space for radio button + margin
+  width: 100%;
+  background-color: white;
+  border-radius: 10px;
+  margin: 2px;
+  box-sizing: border-box; // Ensure padding is included in width calculations
+}
+
+.project-type-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.project-type-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background-color: rgba(25, 118, 210, 0.1);
+  flex-shrink: 0;
+  transition: all 0.2s ease-in-out;
+
+  mat-icon {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: #1976d2;
+    transition: all 0.2s ease-in-out;
+  }
+}
+
+.project-type-info {
+  flex: 1;
+  min-width: 0; // Allow text to wrap properly
+  max-width: 100%; // Prevent overflow
+  overflow-wrap: break-word; // Break long words if needed
+  word-wrap: break-word; // Legacy support
+
+  h4 {
+    margin: 0 0 8px 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.87);
+    line-height: 1.3;
+    overflow-wrap: break-word;
+  }
+}
+
+.project-type-description {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.65);
+  line-height: 1.5;
+  font-size: 0.9rem;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto; // Allow hyphenation for better text flow
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.field-error {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: #f44336;
+}
+
+.dialog-actions {
+  padding: 24px !important;
+  margin: 0;
+  justify-content: flex-end;
+  gap: 12px;
+  border-top: 1px solid #e0e0e0;
+
+  button {
+    min-width: 80px;
+    height: 40px;
+
+    &[mat-raised-button] {
+      min-width: 140px;
+    }
+  }
+}
+
+.button-spinner {
+  margin-right: 8px;
+
+  ::ng-deep circle {
+    stroke: white;
+  }
+}
+
+// Dialog title styling to ensure proper padding
+::ng-deep .mat-mdc-dialog-title {
+  padding: 16px 24px 0 24px !important;
+  margin: 0 !important;
+}
+
+// Ensure dialog container can grow
+::ng-deep .mat-mdc-dialog-container {
+  max-height: 80vh !important;
+  height: auto !important;
+}
+
+// Success and error snackbar styles
+::ng-deep .success-snackbar {
+  background-color: #4caf50 !important;
+  color: white !important;
+}
+
+::ng-deep .error-snackbar {
+  background-color: #f44336 !important;
+  color: white !important;
+}
+
+// Responsive adjustments
+@media (max-width: 600px) {
+  .dialog-content {
+    padding: 16px !important;
+    min-height: 400px;
+    max-height: 85vh; // Slightly more space on mobile
+  }
+
+  ::ng-deep .mat-mdc-dialog-title {
+    padding: 12px 16px 0 16px !important;
+  }
+
+  .dialog-actions {
+    padding: 16px !important;
+  }
+
+  .project-type-content {
+    padding: 20px;
+    padding-right: 64px; // Adjusted for mobile radio button space
+  }
+
+  .project-type-header {
+    gap: 12px;
+    margin-bottom: 10px;
+  }
+
+  .project-type-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 10px;
+
+    mat-icon {
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .project-type-info h4 {
+    font-size: 1.125rem;
+  }
+
+  .project-type-description {
+    font-size: 0.875rem;
+  }
+}

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.spec.ts
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateProjectDialogComponent } from './create-project-dialog.component';
+
+describe('CreateProjectDialogComponent', () => {
+  let component: CreateProjectDialogComponent;
+  let fixture: ComponentFixture<CreateProjectDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreateProjectDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreateProjectDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.spec.ts
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.spec.ts
@@ -9,8 +9,7 @@ describe('CreateProjectDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CreateProjectDialogComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CreateProjectDialogComponent);
     component = fixture.componentInstance;

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.ts
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.ts
@@ -1,0 +1,149 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { ProjectType } from '@reefguide/db';
+import { CreateProjectInput } from '@reefguide/types';
+import { BehaviorSubject, finalize } from 'rxjs';
+import { WebApiService } from '../../../api/web-api.service';
+
+interface ProjectTypeOption {
+  value: ProjectType;
+  label: string;
+  description: string;
+  icon: string; // Placeholder for icon
+}
+
+@Component({
+  selector: 'app-create-project-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatRadioModule,
+    MatSnackBarModule
+  ],
+  templateUrl: './create-project-dialog.component.html',
+  styleUrls: ['./create-project-dialog.component.scss']
+})
+export class CreateProjectDialogComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly dialogRef = inject(MatDialogRef<CreateProjectDialogComponent>);
+  private readonly webApi = inject(WebApiService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  isLoading$ = new BehaviorSubject<boolean>(false);
+
+  projectTypes: ProjectTypeOption[] = [
+    {
+      value: 'SITE_SELECTION',
+      label: 'Site Selection',
+      description:
+        'Analyze and select optimal sites for reef restoration projects based on environmental criteria and constraints.',
+      icon: 'location_on' // Placeholder - you can replace with your actual icon
+    },
+    {
+      value: 'ADRIA_ANALYSIS',
+      label: 'ADRIA Analysis',
+      description:
+        'Perform comprehensive reef ecosystem modeling and intervention analysis using the ADRIA platform.',
+      icon: 'analytics' // Placeholder - you can replace with your actual icon
+    }
+  ];
+
+  createForm: FormGroup = this.fb.group({
+    name: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(255)]],
+    description: ['', [Validators.maxLength(1000)]],
+    type: ['', [Validators.required]]
+  });
+
+  onCancel() {
+    this.dialogRef.close();
+  }
+
+  onSubmit() {
+    if (this.createForm.valid && !this.isLoading$.value) {
+      this.isLoading$.next(true);
+
+      const formValue = this.createForm.value;
+      const projectData: CreateProjectInput = {
+        name: formValue.name.trim(),
+        description: formValue.description?.trim() || undefined,
+        type: formValue.type,
+        project_state: {} // Initialize with empty state
+      };
+
+      this.webApi
+        .createProject(projectData)
+        .pipe(finalize(() => this.isLoading$.next(false)))
+        .subscribe({
+          next: response => {
+            this.snackBar.open('Project created successfully!', 'Close', {
+              duration: 3000,
+              panelClass: ['success-snackbar']
+            });
+            this.dialogRef.close(response.project);
+          },
+          error: error => {
+            console.error('Error creating project:', error);
+            const errorMessage =
+              error.error?.message || 'Failed to create project. Please try again.';
+            this.snackBar.open(errorMessage, 'Close', {
+              duration: 5000,
+              panelClass: ['error-snackbar']
+            });
+          }
+        });
+    } else {
+      // Mark all fields as touched to show validation errors
+      this.createForm.markAllAsTouched();
+    }
+  }
+
+  getFieldError(fieldName: string): string {
+    const field = this.createForm.get(fieldName);
+    if (field && field.errors && field.touched) {
+      if (field.errors['required']) {
+        return `${this.getFieldDisplayName(fieldName)} is required`;
+      }
+      if (field.errors['minlength']) {
+        return `${this.getFieldDisplayName(fieldName)} must be at least ${field.errors['minlength'].requiredLength} character(s)`;
+      }
+      if (field.errors['maxlength']) {
+        return `${this.getFieldDisplayName(fieldName)} must be no more than ${field.errors['maxlength'].requiredLength} characters`;
+      }
+    }
+    return '';
+  }
+
+  private getFieldDisplayName(fieldName: string): string {
+    switch (fieldName) {
+      case 'name':
+        return 'Project name';
+      case 'description':
+        return 'Description';
+      case 'type':
+        return 'Project type';
+      default:
+        return fieldName;
+    }
+  }
+
+  isFieldInvalid(fieldName: string): boolean {
+    const field = this.createForm.get(fieldName);
+    return !!(field && field.errors && field.touched);
+  }
+}

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.ts
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.ts
@@ -18,7 +18,7 @@ interface ProjectTypeOption {
   value: ProjectType;
   label: string;
   description: string;
-  icon: string; // Placeholder for icon
+  icon: string;
 }
 
 @Component({
@@ -53,14 +53,14 @@ export class CreateProjectDialogComponent {
       label: 'Site Selection',
       description:
         'Analyze and select optimal sites for reef restoration projects based on environmental criteria and constraints.',
-      icon: 'location_on' // Placeholder - you can replace with your actual icon
+      icon: 'location_on'
     },
     {
       value: 'ADRIA_ANALYSIS',
       label: 'ADRIA Analysis',
       description:
         'Perform comprehensive reef ecosystem modeling and intervention analysis using the ADRIA platform.',
-      icon: 'analytics' // Placeholder - you can replace with your actual icon
+      icon: 'analytics'
     }
   ];
 

--- a/packages/app/src/app/projects/projects-list/projects-list.component.html
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.html
@@ -1,0 +1,118 @@
+<div class="projects-container">
+  <!-- Header -->
+  <div class="projects-header">
+    <h1>My Projects</h1>
+  </div>
+
+  <!-- Search and Actions Bar -->
+  <div class="search-actions-bar">
+    <mat-form-field appearance="outline" class="search-field">
+      <mat-label>Search projects</mat-label>
+      <input
+        matInput
+        placeholder="Search by name, description, or type"
+        (input)="onSearchChange($event)"
+        [value]="searchQuery$ | async"
+      />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+
+    <button mat-raised-button color="primary" (click)="openCreateDialog()" class="create-button">
+      <mat-icon>add</mat-icon>
+      Create Project
+    </button>
+  </div>
+
+  <!-- Loading spinner -->
+  <div *ngIf="isLoading$ | async" class="loading-container">
+    <mat-spinner diameter="50"></mat-spinner>
+    <p>Loading projects...</p>
+  </div>
+
+  <!-- Projects list -->
+  <div *ngIf="!(isLoading$ | async)" class="projects-content">
+    <div *ngIf="(paginatedProjects$ | async)?.length === 0" class="empty-state">
+      <mat-icon class="empty-icon">folder_open</mat-icon>
+      <h3>No projects found</h3>
+      <p *ngIf="!(searchQuery$ | async)">Get started by creating your first project</p>
+      <p *ngIf="searchQuery$ | async">Try adjusting your search criteria</p>
+      <button
+        *ngIf="!(searchQuery$ | async)"
+        mat-raised-button
+        color="primary"
+        (click)="openCreateDialog()"
+      >
+        <mat-icon>add</mat-icon>
+        Create Your First Project
+      </button>
+    </div>
+
+    <div *ngIf="(paginatedProjects$ | async)?.length! > 0" class="projects-grid">
+      <mat-card
+        *ngFor="let project of paginatedProjects$ | async; trackBy: trackByProjectId"
+        class="project-card"
+        (click)="onProjectClick(project)"
+        tabindex="0"
+        role="button"
+        [attr.aria-label]="'Open project ' + project.name"
+      >
+        <mat-card-header>
+          <div mat-card-avatar class="project-avatar">
+            <!-- Placeholder for project type icon -->
+            <mat-icon [color]="getProjectTypeColor(project.type)">
+              {{ project.type === 'SITE_SELECTION' ? 'location_on' : 'analytics' }}
+            </mat-icon>
+          </div>
+
+          <mat-card-title>{{ project.name }}</mat-card-title>
+
+          <mat-card-subtitle>
+            <mat-chip [color]="getProjectTypeColor(project.type)">
+              {{ getProjectTypeDisplay(project.type) }}
+            </mat-chip>
+          </mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          <p class="project-description">
+            {{ project.description || 'No description provided' }}
+          </p>
+
+          <div class="project-meta">
+            <div class="meta-item">
+              <mat-icon>schedule</mat-icon>
+              <span>Created {{ project.created_at | date: 'short' }}</span>
+            </div>
+            <div class="meta-item" *ngIf="project.updated_at !== project.created_at">
+              <mat-icon>edit</mat-icon>
+              <span>Updated {{ project.updated_at | date: 'short' }}</span>
+            </div>
+          </div>
+        </mat-card-content>
+
+        <mat-card-actions align="end">
+          <button
+            mat-button
+            color="primary"
+            (click)="onProjectClick(project); $event.stopPropagation()"
+          >
+            Open
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+
+    <!-- Pagination -->
+    <mat-paginator
+      *ngIf="totalProjects > pageSize"
+      #paginator
+      [length]="totalProjects"
+      [pageSize]="pageSize"
+      [pageSizeOptions]="[5, 10, 25, 50]"
+      [showFirstLastButtons]="true"
+      (page)="onPageChange($event)"
+      aria-label="Select page"
+    >
+    </mat-paginator>
+  </div>
+</div>

--- a/packages/app/src/app/projects/projects-list/projects-list.component.scss
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.scss
@@ -1,0 +1,216 @@
+.projects-container {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.projects-header {
+  margin-bottom: 24px;
+
+  h1 {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 500;
+    color: rgba(0, 0, 0, 0.87);
+  }
+}
+
+.search-actions-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 32px;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+}
+
+.search-field {
+  flex: 1;
+  max-width: 400px;
+
+  @media (max-width: 768px) {
+    max-width: none;
+    width: 100%;
+  }
+}
+
+.create-button {
+  height: 56px; // Match the search field height
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  mat-icon {
+    margin-right: 8px;
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 16px;
+  text-align: center;
+
+  p {
+    margin-top: 16px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+}
+
+.projects-content {
+  min-height: 400px;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 16px;
+  text-align: center;
+
+  .empty-icon {
+    font-size: 64px;
+    width: 64px;
+    height: 64px;
+    color: rgba(0, 0, 0, 0.3);
+    margin-bottom: 16px;
+  }
+
+  h3 {
+    margin: 0 0 8px 0;
+    color: rgba(0, 0, 0, 0.87);
+  }
+
+  p {
+    margin: 0 0 24px 0;
+    color: rgba(0, 0, 0, 0.6);
+    max-width: 400px;
+  }
+
+  button mat-icon {
+    margin-right: 8px;
+  }
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}
+
+.project-card {
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  &:focus {
+    outline: 2px solid #1976d2;
+    outline-offset: 2px;
+  }
+
+  .project-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: rgba(0, 0, 0, 0.04);
+
+    mat-icon {
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  mat-card-header {
+    margin-bottom: 16px;
+
+    mat-card-title {
+      font-size: 1.25rem;
+      font-weight: 500;
+      line-height: 1.2;
+      margin-bottom: 8px;
+    }
+
+    mat-card-subtitle {
+      margin-bottom: 0;
+
+      mat-chip {
+        font-size: 0.75rem;
+        height: 24px;
+        border-radius: 12px;
+      }
+    }
+  }
+
+  mat-card-content {
+    padding-top: 0;
+
+    .project-description {
+      margin: 0 0 16px 0;
+      color: rgba(0, 0, 0, 0.6);
+      line-height: 1.5;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      min-height: 4.5em; // 3 lines worth of height
+    }
+
+    .project-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      .meta-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: rgba(0, 0, 0, 0.5);
+        font-size: 0.875rem;
+
+        mat-icon {
+          font-size: 16px;
+          width: 16px;
+          height: 16px;
+        }
+      }
+    }
+  }
+
+  mat-card-actions {
+    padding-top: 16px;
+    margin-top: auto;
+  }
+}
+
+mat-paginator {
+  margin-top: 32px;
+  border: none;
+  background: transparent;
+}

--- a/packages/app/src/app/projects/projects-list/projects-list.component.spec.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectsListComponent } from './projects-list.component';
+
+describe('ProjectsListComponent', () => {
+  let component: ProjectsListComponent;
+  let fixture: ComponentFixture<ProjectsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectsListComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/projects/projects-list/projects-list.component.spec.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.spec.ts
@@ -9,8 +9,7 @@ describe('ProjectsListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProjectsListComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProjectsListComponent);
     component = fixture.componentInstance;

--- a/packages/app/src/app/projects/projects-list/projects-list.component.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.ts
@@ -151,7 +151,7 @@ export class ProjectsListComponent implements OnInit {
         break;
       case 'SITE_SELECTION':
         // Navigate to site selection workflow when available
-        this.router.navigate(['/projects', project.id, 'site-selection']);
+        this.router.navigate(['/location-selection', project.id]);
         console.log("Ran nav function")
         break;
       default:

--- a/packages/app/src/app/projects/projects-list/projects-list.component.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.ts
@@ -1,0 +1,201 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, OnInit, ViewChild } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { Project } from '@reefguide/db';
+import { BehaviorSubject, combineLatest, debounceTime, distinctUntilChanged, map, Observable, startWith, switchMap } from 'rxjs';
+import { WebApiService } from '../../../api/web-api.service';
+import { CreateProjectDialogComponent } from '../create-project-dialog/create-project-dialog.component';
+
+@Component({
+  selector: 'app-projects-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatChipsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatPaginatorModule,
+    MatProgressSpinnerModule,
+    MatRadioModule,
+    MatSnackBarModule
+  ],
+  templateUrl: './projects-list.component.html',
+  styleUrls: ['./projects-list.component.scss']
+})
+export class ProjectsListComponent implements OnInit {
+  private readonly webApi = inject(WebApiService);
+  private readonly dialog = inject(MatDialog);
+  private readonly router = inject(Router);
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  // Search and pagination state
+  searchQuery$ = new BehaviorSubject<string>('');
+  pageSize = 10;
+  currentPage = 0;
+  totalProjects = 0;
+
+  // All projects from the server
+  allProjects$ = this.webApi.getUserProjects().pipe(
+    map(response => response.projects)
+  );
+
+  // Filtered projects based on search
+  filteredProjects$: Observable<Project[]> = combineLatest([
+    this.allProjects$,
+    this.searchQuery$.pipe(
+      debounceTime(300),
+      distinctUntilChanged()
+    )
+  ]).pipe(
+    map(([projects, searchQuery]) => {
+      if (!searchQuery.trim()) {
+        return projects;
+      }
+
+      const query = searchQuery.toLowerCase().trim();
+      return projects.filter(project =>
+        project.name.toLowerCase().includes(query) ||
+        (project.description && project.description.toLowerCase().includes(query)) ||
+        project.type.toLowerCase().includes(query)
+      );
+    })
+  );
+
+  // Paginated projects
+  paginatedProjects$: Observable<Project[]> = combineLatest([
+    this.filteredProjects$,
+    this.paginator ? this.paginator.page.pipe(startWith({ pageIndex: 0, pageSize: this.pageSize })) :
+      new BehaviorSubject({ pageIndex: 0, pageSize: this.pageSize })
+  ]).pipe(
+    map(([projects, pageEvent]) => {
+      this.totalProjects = projects.length;
+      const startIndex = pageEvent.pageIndex * pageEvent.pageSize;
+      const endIndex = startIndex + pageEvent.pageSize;
+      return projects.slice(startIndex, endIndex);
+    })
+  );
+
+  isLoading$ = new BehaviorSubject<boolean>(true);
+
+  ngOnInit() {
+    // Set loading to false when projects are loaded
+    this.allProjects$.subscribe(() => {
+      this.isLoading$.next(false);
+    });
+  }
+
+  onSearchChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.searchQuery$.next(target.value);
+    // Reset to first page when searching
+    if (this.paginator) {
+      this.paginator.firstPage();
+    }
+  }
+
+  onPageChange(event: PageEvent) {
+    this.currentPage = event.pageIndex;
+    this.pageSize = event.pageSize;
+  }
+
+  openCreateDialog() {
+    const dialogRef = this.dialog.open(CreateProjectDialogComponent, {
+      width: '600px',
+      disableClose: true
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.onProjectCreated(result);
+      }
+    });
+  }
+
+  onProjectCreated(project: Project) {
+    // Event hook for when a project is created
+    // For now, just refresh the list
+    this.refreshProjects();
+
+    // Navigate to the appropriate workflow based on project type
+    this.navigateToProject(project);
+  }
+
+  onProjectClick(project: Project) {
+    // Navigate to the appropriate workflow based on project type
+    this.navigateToProject(project);
+  }
+
+  private navigateToProject(project: Project) {
+    switch (project.type) {
+      case 'ADRIA_ANALYSIS':
+        this.router.navigate(['/adria', project.id]);
+        console.log("Ran nav function")
+        break;
+      case 'SITE_SELECTION':
+        // Navigate to site selection workflow when available
+        this.router.navigate(['/projects', project.id, 'site-selection']);
+        console.log("Ran nav function")
+        break;
+      default:
+        console.warn('Unknown project type:', project.type);
+        // Fallback to a generic project view
+        this.router.navigate(['/projects', project.id]);
+        break;
+    }
+  }
+
+  refreshProjects() {
+    this.isLoading$.next(true);
+    this.allProjects$ = this.webApi.getUserProjects().pipe(
+      map(response => response.projects)
+    );
+
+    this.allProjects$.subscribe(() => {
+      this.isLoading$.next(false);
+    });
+  }
+
+  getProjectTypeDisplay(type: string): string {
+    switch (type) {
+      case 'SITE_SELECTION':
+        return 'Site Selection';
+      case 'ADRIA_ANALYSIS':
+        return 'ADRIA Analysis';
+      default:
+        return type;
+    }
+  }
+
+  getProjectTypeColor(type: string): string {
+    switch (type) {
+      case 'SITE_SELECTION':
+        return 'primary';
+      case 'ADRIA_ANALYSIS':
+        return 'accent';
+      default:
+        return 'basic';
+    }
+  }
+
+  trackByProjectId(index: number, project: Project): number {
+    return project.id;
+  }
+}

--- a/packages/app/src/app/projects/projects-list/projects-list.component.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.ts
@@ -14,7 +14,18 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { Project } from '@reefguide/db';
-import { BehaviorSubject, combineLatest, debounceTime, distinctUntilChanged, map, Observable, startWith, switchMap, merge, EMPTY } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  Observable,
+  startWith,
+  switchMap,
+  merge,
+  EMPTY
+} from 'rxjs';
 import { WebApiService } from '../../../api/web-api.service';
 import { CreateProjectDialogComponent } from '../create-project-dialog/create-project-dialog.component';
 
@@ -56,17 +67,12 @@ export class ProjectsListComponent implements OnInit {
   private pageEvent$ = new BehaviorSubject<PageEvent>({ pageIndex: 0, pageSize: 10, length: 0 });
 
   // All projects from the server
-  allProjects$ = this.webApi.getUserProjects().pipe(
-    map(response => response.projects)
-  );
+  allProjects$ = this.webApi.getUserProjects().pipe(map(response => response.projects));
 
   // Filtered projects based on search
   filteredProjects$: Observable<Project[]> = combineLatest([
     this.allProjects$,
-    this.searchQuery$.pipe(
-      debounceTime(300),
-      distinctUntilChanged()
-    )
+    this.searchQuery$.pipe(debounceTime(300), distinctUntilChanged())
   ]).pipe(
     map(([projects, searchQuery]) => {
       if (!searchQuery.trim()) {
@@ -74,10 +80,11 @@ export class ProjectsListComponent implements OnInit {
       }
 
       const query = searchQuery.toLowerCase().trim();
-      return projects.filter(project =>
-        project.name.toLowerCase().includes(query) ||
-        (project.description && project.description.toLowerCase().includes(query)) ||
-        project.type.toLowerCase().includes(query)
+      return projects.filter(
+        project =>
+          project.name.toLowerCase().includes(query) ||
+          (project.description && project.description.toLowerCase().includes(query)) ||
+          project.type.toLowerCase().includes(query)
       );
     })
   );
@@ -104,10 +111,7 @@ export class ProjectsListComponent implements OnInit {
     });
 
     // Reset to first page when search changes
-    this.searchQuery$.pipe(
-      debounceTime(300),
-      distinctUntilChanged()
-    ).subscribe(() => {
+    this.searchQuery$.pipe(debounceTime(300), distinctUntilChanged()).subscribe(() => {
       this.pageEvent$.next({ pageIndex: 0, pageSize: this.pageSize, length: 0 });
     });
   }
@@ -155,12 +159,12 @@ export class ProjectsListComponent implements OnInit {
     switch (project.type) {
       case 'ADRIA_ANALYSIS':
         this.router.navigate(['/adria', project.id]);
-        console.log("Ran nav function")
+        console.log('Ran nav function');
         break;
       case 'SITE_SELECTION':
         // Navigate to site selection workflow when available
         this.router.navigate(['/location-selection', project.id]);
-        console.log("Ran nav function")
+        console.log('Ran nav function');
         break;
       default:
         console.warn('Unknown project type:', project.type);
@@ -172,9 +176,7 @@ export class ProjectsListComponent implements OnInit {
 
   refreshProjects() {
     this.isLoading$.next(true);
-    this.allProjects$ = this.webApi.getUserProjects().pipe(
-      map(response => response.projects)
-    );
+    this.allProjects$ = this.webApi.getUserProjects().pipe(map(response => response.projects));
 
     this.allProjects$.subscribe(() => {
       this.isLoading$.next(false);

--- a/packages/db/prisma/migrations/20250710044700_projects/migration.sql
+++ b/packages/db/prisma/migrations/20250710044700_projects/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "ProjectType" AS ENUM ('SITE_SELECTION', 'ADRIA_ANALYSIS');
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "type" "ProjectType" NOT NULL,
+    "project_state" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "user_id" INTEGER NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,11 @@ enum UserRole {
     DEFAULT
 }
 
+enum ProjectType {
+    SITE_SELECTION
+    ADRIA_ANALYSIS
+}
+
 // User - linked to passport js
 model User {
     id              Int               @id @default(autoincrement())
@@ -29,6 +34,7 @@ model User {
     jobRequests     JobRequest[]
     log             UserLog[]
     PreApprovedUser PreApprovedUser[]
+    projects        Project[]
 }
 
 enum UserAction {
@@ -72,6 +78,24 @@ model PreApprovedUser {
     used_at            DateTime?
 
     @@map("pre_approved_users")
+}
+
+// Project model - users can have multiple projects
+model Project {
+    id            Int         @id @default(autoincrement())
+    name          String
+    description   String?
+    type          ProjectType
+    // JSON field for project state - will be typed with Zod in application layer
+    project_state Json
+    created_at    DateTime    @default(now())
+    updated_at    DateTime    @updatedAt
+
+    // Relations
+    user    User @relation(fields: [user_id], references: [id], onDelete: Cascade)
+    user_id Int
+
+    @@map("projects")
 }
 
 // User submitted polygon - has notes

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -5,7 +5,9 @@ import {
   PreApprovedUser,
   StorageScheme,
   UserAction,
-  UserRole
+  UserRole,
+  ProjectType,
+  Project
 } from '@reefguide/db';
 
 // Auth schemas
@@ -458,3 +460,80 @@ export const invalidateCacheResponseSchema = z.object({
   })
 });
 export type InvalidateCacheResponse = z.infer<typeof invalidateCacheResponseSchema>;
+
+// ==================
+// Project Types and Schemas
+// ==================
+
+// Project Input Schemas
+export const CreateProjectInputSchema = z.object({
+  name: z.string().min(1, 'Project name is required'),
+  description: z.string().optional(),
+  type: z.nativeEnum(ProjectType),
+  project_state: z.any()
+});
+export type CreateProjectInput = z.infer<typeof CreateProjectInputSchema>;
+
+export const UpdateProjectInputSchema = z.object({
+  name: z.string().min(1, 'Project name is required').optional(),
+  description: z.string().optional(),
+  project_state: z.any().optional()
+});
+export type UpdateProjectInput = z.infer<typeof UpdateProjectInputSchema>;
+
+export const BulkCreateProjectsInputSchema = z.object({
+  projects: z.array(CreateProjectInputSchema).min(1, 'At least one project must be provided'),
+  userId: z.number().min(1, 'User ID is required')
+});
+export type BulkCreateProjectsInput = z.infer<typeof BulkCreateProjectsInputSchema>;
+
+// Query Schemas
+export const GetProjectsQuerySchema = z.object({
+  type: z.nativeEnum(ProjectType).optional(),
+  name: z.string().optional(),
+  userId: z.number().optional(),
+  limit: z.number().optional(),
+  offset: z.number().optional()
+});
+export type GetProjectsQuery = z.infer<typeof GetProjectsQuerySchema>;
+
+export const ProjectParamsSchema = z.object({
+  id: z.string().regex(/^\d+$/, 'Project ID must be a number')
+});
+export type ProjectParams = z.infer<typeof ProjectParamsSchema>;
+
+// Response Types
+export type CreateProjectResponse = {
+  project: Project;
+};
+
+export type UpdateProjectResponse = {
+  project: Project;
+};
+
+export type GetProjectResponse = {
+  project: Project;
+};
+
+export type GetProjectsResponse = {
+  projects: Project[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+};
+
+export type DeleteProjectResponse = {
+  message: string;
+};
+
+export type BulkCreateProjectsResponse = {
+  created: Project[];
+  errors: Array<{ name: string; error: string }>;
+  summary: {
+    totalRequested: number;
+    totalCreated: number;
+    totalErrors: number;
+  };
+};

--- a/packages/web-api/src/apiSetup.ts
+++ b/packages/web-api/src/apiSetup.ts
@@ -11,6 +11,7 @@ import * as middlewares from './middlewares';
 import { router as noteRoutes } from './notes/routes';
 import { router as polygonRoutes } from './polygons/routes';
 import { router as userRoutes } from './users/routes';
+import { router as projectRoutes } from './projects/routes';
 
 require('dotenv').config();
 require('express-async-errors');
@@ -51,6 +52,7 @@ api.use('/notes', noteRoutes);
 api.use('/admin', adminRoutes);
 api.use('/users', userRoutes);
 api.use('/jobs', jobRoutes);
+api.use('/projects', projectRoutes);
 
 // API base router
 app.use('/api', api);

--- a/packages/web-api/src/projects/routes.ts
+++ b/packages/web-api/src/projects/routes.ts
@@ -1,19 +1,18 @@
-import { prisma, ProjectType } from '@reefguide/db';
+import { prisma } from '@reefguide/db';
 import {
-  CreateProjectInputSchema,
-  UpdateProjectInputSchema,
-  CreateProjectResponse,
-  UpdateProjectResponse,
-  GetProjectResponse,
-  GetProjectsResponse,
-  DeleteProjectResponse,
   BulkCreateProjectsInputSchema,
   BulkCreateProjectsResponse,
+  CreateProjectInputSchema,
+  CreateProjectResponse,
+  DeleteProjectResponse,
+  GetProjectResponse,
+  GetProjectsQuerySchema,
+  GetProjectsResponse,
   ProjectParamsSchema,
-  GetProjectsQuerySchema
+  UpdateProjectInputSchema,
+  UpdateProjectResponse
 } from '@reefguide/types';
 import express, { Response, Router } from 'express';
-import { z } from 'zod';
 import { processRequest } from 'zod-express-middleware';
 import { passport } from '../auth/passportConfig';
 import { assertUserHasRoleMiddleware } from '../auth/utils';

--- a/packages/web-api/src/projects/routes.ts
+++ b/packages/web-api/src/projects/routes.ts
@@ -1,0 +1,288 @@
+import { prisma, ProjectType } from '@reefguide/db';
+import {
+  CreateProjectInputSchema,
+  UpdateProjectInputSchema,
+  CreateProjectResponse,
+  UpdateProjectResponse,
+  GetProjectResponse,
+  GetProjectsResponse,
+  DeleteProjectResponse,
+  BulkCreateProjectsInputSchema,
+  BulkCreateProjectsResponse,
+  ProjectParamsSchema,
+  GetProjectsQuerySchema
+} from '@reefguide/types';
+import express, { Response, Router } from 'express';
+import { z } from 'zod';
+import { processRequest } from 'zod-express-middleware';
+import { passport } from '../auth/passportConfig';
+import { assertUserHasRoleMiddleware } from '../auth/utils';
+import { BadRequestException, InternalServerError, NotFoundException } from '../exceptions';
+import { ProjectService } from './service';
+
+require('express-async-errors');
+export const router: Router = express.Router();
+
+/**
+ * Create a new project
+ */
+router.post(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  processRequest({
+    body: CreateProjectInputSchema
+  }),
+  async (req, res: Response<CreateProjectResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectService = new ProjectService(prisma);
+      const project = await projectService.create({
+        input: req.body,
+        userId: req.user.id
+      });
+
+      res.status(201).json({ project });
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      throw new InternalServerError('Failed to create project. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Get projects with optional filtering
+ */
+router.get(
+  '/',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  processRequest({
+    query: GetProjectsQuerySchema
+  }),
+  async (req, res: Response<GetProjectsResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectService = new ProjectService(prisma);
+
+      // Parse and validate query parameters
+      const limit = req.query.limit;
+      const offset = req.query.offset;
+      const type = req.query.type;
+
+      // Validate type if provided
+      if (type && !['SITE_SELECTION', 'ADRIA_ANALYSIS'].includes(type)) {
+        throw new BadRequestException(
+          `Invalid project type: ${type}. Must be SITE_SELECTION or ADRIA_ANALYSIS`
+        );
+      }
+
+      // Users can only see their own projects unless they're admin
+      const options = {
+        type,
+        name: req.query.name,
+        limit,
+        offset,
+        userId: req.user.roles.includes('ADMIN') ? undefined : req.user.id
+      };
+
+      const projects = await projectService.getMany({ options });
+      const total = await projectService.getCount({ options });
+
+      res.json({
+        projects,
+        pagination: {
+          total,
+          limit: limit ?? 50,
+          offset: offset ?? 0
+        }
+      });
+    } catch (error) {
+      throw new InternalServerError('Failed to get projects. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Get a specific project by ID
+ */
+router.get(
+  '/:id',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  processRequest({
+    params: ProjectParamsSchema
+  }),
+  async (req, res: Response<GetProjectResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectId = parseInt(req.params.id, 10);
+      const projectService = new ProjectService(prisma);
+
+      // Users can only see their own projects unless they're admin
+      const userId = req.user.roles.includes('ADMIN') ? undefined : req.user.id;
+
+      const project = await projectService.getById({ id: projectId, userId });
+
+      if (!project) {
+        throw new NotFoundException(`Project with ID ${projectId} not found`);
+      }
+
+      res.json({ project });
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      throw new InternalServerError('Failed to get project. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Update a project
+ */
+router.put(
+  '/:id',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  processRequest({
+    params: ProjectParamsSchema,
+    body: UpdateProjectInputSchema
+  }),
+  async (req, res: Response<UpdateProjectResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectId = parseInt(req.params.id, 10);
+      const projectService = new ProjectService(prisma);
+
+      // Users can only update their own projects unless they're admin
+      const userId = req.user.roles.includes('ADMIN') ? undefined : req.user.id;
+
+      const project = await projectService.update({
+        id: projectId,
+        input: req.body,
+        userId
+      });
+
+      res.json({ project });
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadRequestException) throw error;
+      throw new InternalServerError('Failed to update project. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Delete a project
+ */
+router.delete(
+  '/:id',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  processRequest({
+    params: ProjectParamsSchema
+  }),
+  async (req, res: Response<DeleteProjectResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectId = parseInt(req.params.id, 10);
+      const projectService = new ProjectService(prisma);
+
+      // Users can only delete their own projects unless they're admin
+      const userId = req.user.roles.includes('ADMIN') ? undefined : req.user.id;
+
+      const deleted = await projectService.delete({ id: projectId, userId });
+
+      if (!deleted) {
+        throw new NotFoundException(`Project with ID ${projectId} not found`);
+      }
+
+      res.json({ message: 'Project deleted successfully' });
+    } catch (error) {
+      if (error instanceof NotFoundException) throw error;
+      throw new InternalServerError('Failed to delete project. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Get current user's projects
+ */
+router.get(
+  '/user/me',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  async (req, res: Response<GetProjectsResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const projectService = new ProjectService(prisma);
+      const projects = await projectService.getByUserId({ userId: req.user.id });
+
+      res.json({
+        projects,
+        pagination: {
+          total: projects.length,
+          limit: projects.length,
+          offset: 0
+        }
+      });
+    } catch (error) {
+      throw new InternalServerError('Failed to get user projects. Error: ' + error, error as Error);
+    }
+  }
+);
+
+/**
+ * Bulk create projects (admin only)
+ */
+router.post(
+  '/bulk',
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ADMIN'] }),
+  processRequest({
+    body: BulkCreateProjectsInputSchema
+  }),
+  async (req, res: Response<BulkCreateProjectsResponse>) => {
+    if (!req.user) {
+      throw new InternalServerError('User object was not available after authorization.');
+    }
+
+    try {
+      const { projects, userId } = req.body;
+      const projectService = new ProjectService(prisma);
+
+      const result = await projectService.bulkCreate({ inputs: projects, userId });
+
+      res.status(201).json({
+        created: result.created,
+        errors: result.errors,
+        summary: {
+          totalRequested: projects.length,
+          totalCreated: result.created.length,
+          totalErrors: result.errors.length
+        }
+      });
+    } catch (error) {
+      throw new InternalServerError(
+        'Failed to bulk create projects. Error: ' + error,
+        error as Error
+      );
+    }
+  }
+);

--- a/packages/web-api/src/projects/service.ts
+++ b/packages/web-api/src/projects/service.ts
@@ -64,7 +64,9 @@ export class ProjectService {
     });
 
     if (existingProject) {
-      throw new BadRequestException(`Project with name "${input.name}" already exists for this user`);
+      throw new BadRequestException(
+        `Project with name "${input.name}" already exists for this user`
+      );
     }
 
     return await this.prisma.project.create({
@@ -170,7 +172,15 @@ export class ProjectService {
    * @returns Promise<Project> - The updated project
    * @throws Error if project not found or user doesn't have permission
    */
-  async update({ id, input, userId }: { id: number; input: UpdateProjectInput; userId?: number }): Promise<Project> {
+  async update({
+    id,
+    input,
+    userId
+  }: {
+    id: number;
+    input: UpdateProjectInput;
+    userId?: number;
+  }): Promise<Project> {
     // Check if project exists and user has permission
     const existing = await this.prisma.project.findFirst({
       where: {
@@ -180,7 +190,9 @@ export class ProjectService {
     });
 
     if (!existing) {
-      throw new NotFoundException(`Project with ID ${id} not found` + (userId ? ' for this user' : ''));
+      throw new NotFoundException(
+        `Project with ID ${id} not found` + (userId ? ' for this user' : '')
+      );
     }
 
     // If updating name, check for conflicts within the same user
@@ -194,7 +206,9 @@ export class ProjectService {
       });
 
       if (nameConflict) {
-        throw new BadRequestException(`Project with name "${input.name}" already exists for this user`);
+        throw new BadRequestException(
+          `Project with name "${input.name}" already exists for this user`
+        );
       }
     }
 

--- a/packages/web-api/src/projects/service.ts
+++ b/packages/web-api/src/projects/service.ts
@@ -1,0 +1,322 @@
+import { PrismaClient, ProjectType, Project, Prisma } from '@reefguide/db';
+import { BadRequestException, NotFoundException } from '../exceptions';
+import { CreateProjectInput, UpdateProjectInput } from '@reefguide/types';
+
+/**
+ * Options for querying projects
+ */
+export interface GetProjectsOptions {
+  userId?: number;
+  type?: ProjectType;
+  name?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Service class for managing projects
+ * Provides CRUD operations and business logic for the project workflow
+ */
+export class ProjectService {
+  private prisma: PrismaClient | Prisma.TransactionClient;
+
+  constructor(prisma: PrismaClient | Prisma.TransactionClient) {
+    this.prisma = prisma;
+  }
+
+  /**
+   * Creates a new project
+   *
+   * @param input - The project data
+   * @param userId - The ID of the user creating the project
+   * @returns Promise<Project> - The created project
+   * @throws Error if user not found or validation fails
+   */
+  async create({ input, userId }: { input: CreateProjectInput; userId: number }): Promise<Project> {
+    // Validate input
+    if (!input.name || !input.name.trim()) {
+      throw new BadRequestException('Project name is required');
+    }
+
+    if (!input.type) {
+      throw new BadRequestException('Project type is required');
+    }
+
+    if (!input.project_state) {
+      throw new BadRequestException('Project state is required');
+    }
+
+    // Validate that the user exists
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId }
+    });
+
+    if (!user) {
+      throw new BadRequestException(`User with ID ${userId} not found`);
+    }
+
+    // Check if a project with the same name already exists for this user
+    const existingProject = await this.prisma.project.findFirst({
+      where: {
+        user_id: userId,
+        name: input.name.trim()
+      }
+    });
+
+    if (existingProject) {
+      throw new BadRequestException(`Project with name "${input.name}" already exists for this user`);
+    }
+
+    return await this.prisma.project.create({
+      data: {
+        name: input.name.trim(),
+        description: input.description?.trim() || null,
+        type: input.type,
+        project_state: input.project_state,
+        user_id: userId
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true
+          }
+        }
+      }
+    });
+  }
+
+  /**
+   * Retrieves multiple projects with optional filtering
+   *
+   * @param options - Query options for filtering and pagination
+   * @returns Promise<Project[]> - Array of matching projects
+   */
+  async getMany({ options = {} }: { options?: GetProjectsOptions }): Promise<Project[]> {
+    const { userId, type, name, limit = 50, offset = 0 } = options;
+
+    return await this.prisma.project.findMany({
+      where: {
+        ...(userId && { user_id: userId }),
+        ...(type && { type }),
+        ...(name && { name: { contains: name, mode: 'insensitive' } })
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true
+          }
+        }
+      },
+      orderBy: {
+        updated_at: 'desc'
+      },
+      take: Math.min(limit, 100), // Cap at 100 for performance
+      skip: offset
+    });
+  }
+
+  /**
+   * Gets count of projects matching the given criteria
+   *
+   * @param options - Query options for filtering
+   * @returns Promise<number> - Count of matching records
+   */
+  async getCount({ options = {} }: { options?: GetProjectsOptions }): Promise<number> {
+    const { userId, type, name } = options;
+
+    return await this.prisma.project.count({
+      where: {
+        ...(userId && { user_id: userId }),
+        ...(type && { type }),
+        ...(name && { name: { contains: name, mode: 'insensitive' } })
+      }
+    });
+  }
+
+  /**
+   * Retrieves a project by ID
+   *
+   * @param id - The ID of the project
+   * @param userId - Optional user ID to ensure ownership
+   * @returns Promise<Project | undefined> - The project or undefined if not found
+   */
+  async getById({ id, userId }: { id: number; userId?: number }): Promise<Project | undefined> {
+    return (
+      (await this.prisma.project.findFirst({
+        where: {
+          id,
+          ...(userId && { user_id: userId })
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true
+            }
+          }
+        }
+      })) ?? undefined
+    );
+  }
+
+  /**
+   * Updates an existing project
+   *
+   * @param id - The ID of the project to update
+   * @param input - The updated data
+   * @param userId - Optional user ID to ensure ownership
+   * @returns Promise<Project> - The updated project
+   * @throws Error if project not found or user doesn't have permission
+   */
+  async update({ id, input, userId }: { id: number; input: UpdateProjectInput; userId?: number }): Promise<Project> {
+    // Check if project exists and user has permission
+    const existing = await this.prisma.project.findFirst({
+      where: {
+        id,
+        ...(userId && { user_id: userId })
+      }
+    });
+
+    if (!existing) {
+      throw new NotFoundException(`Project with ID ${id} not found` + (userId ? ' for this user' : ''));
+    }
+
+    // If updating name, check for conflicts within the same user
+    if (input.name) {
+      const nameConflict = await this.prisma.project.findFirst({
+        where: {
+          user_id: existing.user_id,
+          name: input.name.trim(),
+          id: { not: id } // Exclude current project
+        }
+      });
+
+      if (nameConflict) {
+        throw new BadRequestException(`Project with name "${input.name}" already exists for this user`);
+      }
+    }
+
+    return await this.prisma.project.update({
+      where: { id },
+      data: {
+        ...(input.name && { name: input.name.trim() }),
+        ...(input.description !== undefined && { description: input.description?.trim() || null }),
+        ...(input.project_state && { project_state: input.project_state }),
+        updated_at: new Date()
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true
+          }
+        }
+      }
+    });
+  }
+
+  /**
+   * Deletes a project
+   *
+   * @param id - The ID of the project to delete
+   * @param userId - Optional user ID to ensure ownership
+   * @returns Promise<boolean> - True if deleted, false if not found
+   */
+  async delete({ id, userId }: { id: number; userId?: number }): Promise<boolean> {
+    const existing = await this.prisma.project.findFirst({
+      where: {
+        id,
+        ...(userId && { user_id: userId })
+      }
+    });
+
+    if (!existing) {
+      return false;
+    }
+
+    await this.prisma.project.delete({
+      where: { id }
+    });
+
+    return true;
+  }
+
+  /**
+   * Gets all projects for a specific user
+   *
+   * @param userId - The ID of the user
+   * @returns Promise<Project[]> - Array of user's projects
+   */
+  async getByUserId({ userId }: { userId: number }): Promise<Project[]> {
+    return await this.prisma.project.findMany({
+      where: { user_id: userId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true
+          }
+        }
+      },
+      orderBy: {
+        updated_at: 'desc'
+      }
+    });
+  }
+
+  /**
+   * Bulk creates multiple projects for a user
+   * Useful for migration or bulk operations
+   *
+   * @param inputs - Array of project data
+   * @param userId - The ID of the user creating the projects
+   * @returns Promise<{ created: Project[], errors: Array<{name: string, error: string}> }>
+   */
+  async bulkCreate({ inputs, userId }: { inputs: CreateProjectInput[]; userId: number }): Promise<{
+    created: Project[];
+    errors: Array<{ name: string; error: string }>;
+  }> {
+    const created: Project[] = [];
+    const errors: Array<{ name: string; error: string }> = [];
+
+    for (const input of inputs) {
+      try {
+        const project = await this.create({ input, userId });
+        created.push(project);
+      } catch (error) {
+        errors.push({
+          name: input.name,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        });
+      }
+    }
+
+    return { created, errors };
+  }
+
+  /**
+   * Cleans up old projects (for maintenance)
+   * This is a placeholder - you might want to implement based on your business rules
+   *
+   * @param olderThanDays - Delete projects older than this many days (if inactive)
+   * @returns Promise<number> - Number of records deleted
+   */
+  async cleanupOldProjects({ olderThanDays = 365 }: { olderThanDays?: number }): Promise<number> {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - olderThanDays);
+
+    // This is just an example - you might want different cleanup logic
+    const result = await this.prisma.project.deleteMany({
+      where: {
+        updated_at: {
+          lt: cutoffDate
+        }
+        // Add additional conditions like: no recent activity, archived status, etc.
+      }
+    });
+
+    return result.count;
+  }
+}

--- a/packages/web-api/test/app.test.ts
+++ b/packages/web-api/test/app.test.ts
@@ -9,7 +9,7 @@ import { BASE_ROLES } from '../src/auth/routes';
 import { decodeRefreshToken, encodeRefreshToken } from '../src/auth/utils';
 import { InvalidRefreshTokenException } from '../src/exceptions';
 import { JobService } from '../src/services/jobs';
-import { adminToken, clearDbs, user1Email, user1Token, user2Token, userSetup } from './utils';
+import { adminToken, clearDbs, user1Email, user1Token, user2Email, user2Token, userSetup } from './utils';
 
 afterAll(async () => {
   // clear when finished
@@ -1902,6 +1902,349 @@ describe('API', () => {
 
         // Should only affect 1 result (the valid one), not the already invalid one
         expect(res.body.invalidated.affectedResults).toBe(1);
+      });
+    });
+  });
+
+  describe('Projects', () => {
+    let projectId: number;
+
+    beforeEach(async () => {
+      // Create a test project for user1
+      const project = await prisma.project.create({
+        data: {
+          name: 'Test Project',
+          description: 'A test project',
+          type: 'SITE_SELECTION',
+          project_state: { step: 1, data: {} },
+          user_id: user1Id
+        }
+      });
+      projectId = project.id;
+    });
+
+    describe('POST /api/projects', () => {
+      it('should create a new project', async () => {
+        const res = await authRequest(app, 'user1')
+          .post('/api/projects')
+          .send({
+            name: 'New Project',
+            description: 'A new test project',
+            type: 'ADRIA_ANALYSIS',
+            project_state: { step: 1, initialized: true }
+          })
+          .expect(201);
+
+        expect(res.body.project).toHaveProperty('id');
+        expect(res.body.project).toHaveProperty('name', 'New Project');
+        expect(res.body.project).toHaveProperty('type', 'ADRIA_ANALYSIS');
+        expect(res.body.project).toHaveProperty('user_id', user1Id);
+      });
+
+      it('should return 400 for invalid input', async () => {
+        await authRequest(app, 'user1')
+          .post('/api/projects')
+          .send({
+            description: 'Missing name and type'
+          })
+          .expect(400);
+      });
+
+      it('should return 400 for duplicate project name for same user', async () => {
+        await authRequest(app, 'user1')
+          .post('/api/projects')
+          .send({
+            name: 'Test Project', // Same as existing
+            type: 'SITE_SELECTION',
+            project_state: {}
+          })
+          .expect(400);
+      });
+
+      it('should return 401 for unauthenticated request', async () => {
+        await request(app)
+          .post('/api/projects')
+          .send({
+            name: 'Unauthorized Project',
+            type: 'SITE_SELECTION',
+            project_state: {}
+          })
+          .expect(401);
+      });
+    });
+
+    describe('GET /api/projects', () => {
+      it("should return user's projects for non-admin", async () => {
+        const res = await authRequest(app, 'user1').get('/api/projects').expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(1);
+        expect(res.body.projects[0]).toHaveProperty('user_id', user1Id);
+        expect(res.body.pagination).toHaveProperty('total', 1);
+      });
+
+      it('should return all projects for admin', async () => {
+        // Create a project for user2 first
+        const user2 = await prisma.user.findUnique({ where: { email: user2Email } });
+        await prisma.project.create({
+          data: {
+            name: 'User2 Project',
+            type: 'ADRIA_ANALYSIS',
+            project_state: {},
+            user_id: user2!.id
+          }
+        });
+
+        const res = await authRequest(app, 'admin').get('/api/projects').expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('should filter by project type', async () => {
+        // Create an ADRIA_ANALYSIS project
+        await prisma.project.create({
+          data: {
+            name: 'Analysis Project',
+            type: 'ADRIA_ANALYSIS',
+            project_state: {},
+            user_id: user1Id
+          }
+        });
+
+        const res = await authRequest(app, 'user1')
+          .get('/api/projects')
+          .query({ type: 'ADRIA_ANALYSIS' })
+          .expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(1);
+        expect(res.body.projects[0]).toHaveProperty('type', 'ADRIA_ANALYSIS');
+      });
+
+      it('should filter by project name', async () => {
+        const res = await authRequest(app, 'user1')
+          .get('/api/projects')
+          .query({ name: 'Test' })
+          .expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(1);
+        expect(res.body.projects[0].name).toContain('Test');
+      });
+
+      it('should return empty array if user has no projects', async () => {
+        const res = await authRequest(app, 'user2').get('/api/projects').expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(0);
+      });
+    });
+
+    describe('GET /api/projects/:id', () => {
+      it('should return a specific project for its owner', async () => {
+        const res = await authRequest(app, 'user1').get(`/api/projects/${projectId}`).expect(200);
+
+        expect(res.body.project).toHaveProperty('id', projectId);
+        expect(res.body.project).toHaveProperty('name', 'Test Project');
+        expect(res.body.project).toHaveProperty('user_id', user1Id);
+      });
+
+      it('should return a specific project for admin', async () => {
+        const res = await authRequest(app, 'admin').get(`/api/projects/${projectId}`).expect(200);
+
+        expect(res.body.project).toHaveProperty('id', projectId);
+      });
+
+      it("should return 404 if user doesn't own the project", async () => {
+        await authRequest(app, 'user2').get(`/api/projects/${projectId}`).expect(404);
+      });
+
+      it('should return 404 for non-existent project', async () => {
+        await authRequest(app, 'user1').get('/api/projects/9999').expect(404);
+      });
+    });
+
+    describe('PUT /api/projects/:id', () => {
+      it('should update an existing project', async () => {
+        const res = await authRequest(app, 'user1')
+          .put(`/api/projects/${projectId}`)
+          .send({
+            name: 'Updated Project',
+            description: 'Updated description',
+            project_state: { step: 2, updated: true }
+          })
+          .expect(200);
+
+        expect(res.body.project).toHaveProperty('id', projectId);
+        expect(res.body.project).toHaveProperty('name', 'Updated Project');
+        expect(res.body.project).toHaveProperty('description', 'Updated description');
+        expect(res.body.project.project_state).toHaveProperty('step', 2);
+      });
+
+      it('should allow admin to update any project', async () => {
+        const res = await authRequest(app, 'admin')
+          .put(`/api/projects/${projectId}`)
+          .send({
+            name: 'Admin Updated Project'
+          })
+          .expect(200);
+
+        expect(res.body.project).toHaveProperty('name', 'Admin Updated Project');
+      });
+
+      it("should return 404 if user doesn't own the project", async () => {
+        await authRequest(app, 'user2')
+          .put(`/api/projects/${projectId}`)
+          .send({
+            name: 'Unauthorized Update'
+          })
+          .expect(404);
+      });
+
+      it('should return 400 for duplicate project name', async () => {
+        // Create another project for the same user
+        await prisma.project.create({
+          data: {
+            name: 'Another Project',
+            type: 'ADRIA_ANALYSIS',
+            project_state: {},
+            user_id: user1Id
+          }
+        });
+
+        await authRequest(app, 'user1')
+          .put(`/api/projects/${projectId}`)
+          .send({
+            name: 'Another Project' // Duplicate name
+          })
+          .expect(400);
+      });
+
+      it('should return 404 for non-existent project', async () => {
+        await authRequest(app, 'user1')
+          .put('/api/projects/9999')
+          .send({
+            name: 'Non-existent Project'
+          })
+          .expect(404);
+      });
+    });
+
+    describe('DELETE /api/projects/:id', () => {
+      it('should delete an existing project', async () => {
+        await authRequest(app, 'user1').delete(`/api/projects/${projectId}`).expect(200);
+
+        // Verify the project is deleted
+        await authRequest(app, 'user1').get(`/api/projects/${projectId}`).expect(404);
+      });
+
+      it('should allow admin to delete any project', async () => {
+        await authRequest(app, 'admin').delete(`/api/projects/${projectId}`).expect(200);
+
+        // Verify deletion
+        const deleted = await prisma.project.findUnique({
+          where: { id: projectId }
+        });
+        expect(deleted).toBeNull();
+      });
+
+      it("should return 404 if user doesn't own the project", async () => {
+        await authRequest(app, 'user2').delete(`/api/projects/${projectId}`).expect(404);
+      });
+
+      it('should return 404 for non-existent project', async () => {
+        await authRequest(app, 'user1').delete('/api/projects/9999').expect(404);
+      });
+    });
+
+    describe('GET /api/projects/user/me', () => {
+      it("should return current user's projects", async () => {
+        const res = await authRequest(app, 'user1').get('/api/projects/user/me').expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(1);
+        expect(res.body.projects[0]).toHaveProperty('user_id', user1Id);
+        expect(res.body.pagination).toHaveProperty('total', 1);
+      });
+
+      it('should return empty array if user has no projects', async () => {
+        const res = await authRequest(app, 'user2').get('/api/projects/user/me').expect(200);
+
+        expect(res.body.projects).toBeInstanceOf(Array);
+        expect(res.body.projects.length).toBe(0);
+      });
+    });
+
+    describe('POST /api/projects/bulk', () => {
+      it('should bulk create projects (admin only)', async () => {
+        const user2 = await prisma.user.findUnique({ where: { email: user2Email} });
+
+        const res = await authRequest(app, 'admin')
+          .post('/api/projects/bulk')
+          .send({
+            projects: [
+              {
+                name: 'Bulk Project 1',
+                type: 'SITE_SELECTION',
+                project_state: { bulk: true }
+              },
+              {
+                name: 'Bulk Project 2',
+                type: 'ADRIA_ANALYSIS',
+                project_state: { bulk: true }
+              }
+            ],
+            userId: user2!.id
+          })
+          .expect(201);
+
+        expect(res.body.created).toHaveLength(2);
+        expect(res.body.errors).toHaveLength(0);
+        expect(res.body.summary.totalCreated).toBe(2);
+        expect(res.body.summary.totalErrors).toBe(0);
+      });
+
+      it('should handle partial failures in bulk creation', async () => {
+        const res = await authRequest(app, 'admin')
+          .post('/api/projects/bulk')
+          .send({
+            projects: [
+              {
+                name: 'Valid Project',
+                type: 'SITE_SELECTION',
+                project_state: {}
+              },
+              {
+                name: 'Test Project', // Duplicate name for user1
+                type: 'SITE_SELECTION',
+                project_state: {}
+              }
+            ],
+            userId: user1Id
+          })
+          .expect(201);
+
+        expect(res.body.created).toHaveLength(1);
+        expect(res.body.errors).toHaveLength(1);
+        expect(res.body.summary.totalCreated).toBe(1);
+        expect(res.body.summary.totalErrors).toBe(1);
+      });
+
+      it('should return 401 for non-admin users', async () => {
+        await authRequest(app, 'user1')
+          .post('/api/projects/bulk')
+          .send({
+            projects: [
+              {
+                name: 'Unauthorized Bulk',
+                type: 'SITE_SELECTION',
+                project_state: {}
+              }
+            ],
+            userId: user1Id
+          })
+          .expect(401);
       });
     });
   });

--- a/packages/web-api/test/app.test.ts
+++ b/packages/web-api/test/app.test.ts
@@ -9,7 +9,15 @@ import { BASE_ROLES } from '../src/auth/routes';
 import { decodeRefreshToken, encodeRefreshToken } from '../src/auth/utils';
 import { InvalidRefreshTokenException } from '../src/exceptions';
 import { JobService } from '../src/services/jobs';
-import { adminToken, clearDbs, user1Email, user1Token, user2Email, user2Token, userSetup } from './utils';
+import {
+  adminToken,
+  clearDbs,
+  user1Email,
+  user1Token,
+  user2Email,
+  user2Token,
+  userSetup
+} from './utils';
 
 afterAll(async () => {
   // clear when finished
@@ -2178,7 +2186,7 @@ describe('API', () => {
 
     describe('POST /api/projects/bulk', () => {
       it('should bulk create projects (admin only)', async () => {
-        const user2 = await prisma.user.findUnique({ where: { email: user2Email} });
+        const user2 = await prisma.user.findUnique({ where: { email: user2Email } });
 
         const res = await authRequest(app, 'admin')
           .post('/api/projects/bulk')


### PR DESCRIPTION
Adds a user linked object 'Project'.  A project is a container for state which has a name, type, description and basic metadata (created by, at, updated at etc). 

The idea is that the user account is linked to a collection of projects as the main entry point to the various workflows the user can perform in the system. Currently this is 'ADRIA Model Run' or 'Site selection'. ADRIA model run maps to the existing ADRIA model run view, and site selection to the map view. 

The ADRIA Model Run already had browser persistence in local storage - this is enhanced by using the project ID to load/store the state from the API automatically. This required mostly just changes to the persistence service, and being more careful about events emitted from the parameters etc. This seems to work well though the job state/charts are not currently persisted, meaning you need to click submit again to see the job result (but it should be cached). Similarly you can't see the charts until you re-add them back on. This could all be improved in the future by storing these in the state and reinitialising from them. 

The Site selection is just a stub implementation in which I have updated the route to include the project ID, but otherwise the Site Selection project just links to the existing map view - so this isn't working yet. Will need a ticket post open layers migration to persist the sliders/other state to the project and load it up when the component is loaded. 

The home page is now a basic project list with a search bar and create new project dialog

