### PR TITLE
fix: project initial load and detached profile icon

### DIFF
--- a/format-lint.sh
+++ b/format-lint.sh
@@ -1,1 +1,2 @@
-turbo format:write --force && turbo fix --force && turbo lint --force
+turbo='pnpm turbo'
+$turbo format:write --force && $turbo fix --force && $turbo lint --force

--- a/packages/app/src/app/app.component.ts
+++ b/packages/app/src/app/app.component.ts
@@ -60,12 +60,12 @@ export class AppComponent {
   }
 
   /**
-   * Check if the main app content should be rendered
+   * Check if the main app content should be rendered - we now use only render
+   * if the user is authorized to prevent unstable behaviour with queries
+   * failing
    */
   shouldRenderMainContent(): boolean {
-    // Always render content so it loads in background while splash shows
-    // This provides a smoother user experience
-    return true;
+    return this.splashState().userAccessState === 'authorized';
   }
 
   /**

--- a/packages/app/src/app/location-selection/location-selection.component.html
+++ b/packages/app/src/app/location-selection/location-selection.component.html
@@ -104,36 +104,6 @@
       }
     </div>
     -->
-    @if (user) {
-      <button
-        class="profile-button"
-        mat-mini-fab
-        [matMenuTriggerFor]="profileMenu"
-        [matTooltip]="user?.email"
-        matTooltipPosition="left"
-      >
-        <mat-icon>account_circle</mat-icon>
-      </button>
-      <mat-menu #profileMenu="matMenu">
-        <button mat-menu-item (click)="openConfig()">
-          <mat-icon>settings</mat-icon>
-          <span>Settings</span>
-        </button>
-        <button mat-menu-item (click)="authService.logout()">
-          <mat-icon>logout</mat-icon>
-          <span>Logout</span>
-        </button>
-        @if (authService.isAdmin() | async) {
-          <button mat-menu-item (click)="openAdminPanel()">
-            <mat-icon>supervised_user_circle</mat-icon>
-            <span>Manage Users</span>
-          </button>
-          <button mat-menu-item (click)="openClusterAdmin()">
-            <mat-icon>dns</mat-icon>
-            <span>Manage Cluster</span>
-          </button>
-        }
-      </mat-menu>
-    }
+    <app-profile-button />
   </mat-drawer-content>
 </mat-drawer-container>

--- a/packages/app/src/app/location-selection/location-selection.component.scss
+++ b/packages/app/src/app/location-selection/location-selection.component.scss
@@ -53,12 +53,6 @@ mat-drawer {
   }
 }
 
-.profile-button {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-}
-
 .center-container {
   position: absolute;
   top: 0;

--- a/packages/app/src/app/location-selection/location-selection.component.ts
+++ b/packages/app/src/app/location-selection/location-selection.component.ts
@@ -2,7 +2,6 @@ import { AsyncPipe, CommonModule } from '@angular/common';
 import { Component, effect, inject, signal, viewChild, ViewChild } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
@@ -10,22 +9,19 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltip } from '@angular/material/tooltip';
-import { combineLatest, filter, map, Observable } from 'rxjs';
-import { AdminPanelComponent } from '../admin/user-panel/user-panel.component';
+import { SuitabilityAssessmentInput } from '@reefguide/types';
+import Layer from 'ol/layer/Layer';
+import { fromLonLat } from 'ol/proj';
+import { combineLatest, map, Observable } from 'rxjs';
+import { WebApiService } from '../../api/web-api.service';
 import { AuthService } from '../auth/auth.service';
-import { LoginDialogComponent } from '../auth/login-dialog/login-dialog.component';
-import { ClusterAdminDialogComponent } from '../admin/cluster/ClusterAdminDialog.component';
-import { ConfigDialogComponent } from './config-dialog/config-dialog.component';
+import { ReefMapComponent } from '../reef-map/reef-map.component';
+import { ProfileButtonComponent } from '../user/profile-button/profile-button.component';
+import { LayerStyleEditorComponent } from '../widgets/layer-style-editor/layer-style-editor.component';
 import { CriteriaPayloads } from './reef-guide-api.types';
 import { ReefGuideConfigService } from './reef-guide-config.service';
 import { MAP_UI, MapUI, ReefGuideMapService } from './reef-guide-map.service';
 import { SelectionCriteriaComponent } from './selection-criteria/selection-criteria.component';
-import { WebApiService } from '../../api/web-api.service';
-import { SuitabilityAssessmentInput } from '@reefguide/types';
-import { ReefMapComponent } from '../reef-map/reef-map.component';
-import { fromLonLat } from 'ol/proj';
-import Layer from 'ol/layer/Layer';
-import { LayerStyleEditorComponent } from '../widgets/layer-style-editor/layer-style-editor.component';
 
 type DrawerModes = 'criteria' | 'style';
 
@@ -50,7 +46,8 @@ type DrawerModes = 'criteria' | 'style';
     CommonModule,
     MatMenuModule,
     ReefMapComponent,
-    LayerStyleEditorComponent
+    LayerStyleEditorComponent,
+    ProfileButtonComponent
   ],
   providers: [ReefGuideMapService, { provide: MAP_UI, useExisting: LocationSelectionComponent }],
   templateUrl: './location-selection.component.html',
@@ -60,7 +57,6 @@ export class LocationSelectionComponent implements MapUI {
   readonly config = inject(ReefGuideConfigService);
   readonly authService = inject(AuthService);
   readonly api = inject(WebApiService);
-  readonly dialog = inject(MatDialog);
   readonly mapService = inject(ReefGuideMapService);
 
   map = viewChild.required(ReefMapComponent);
@@ -139,26 +135,6 @@ export class LocationSelectionComponent implements MapUI {
     // clear drawer state
     this.editingLayerStyle.set(undefined);
     this.drawerMode.set(undefined);
-  }
-
-  openAdminPanel() {
-    this.dialog.open(AdminPanelComponent, {
-      width: '800px'
-    });
-  }
-
-  openConfig() {
-    this.dialog.open(ConfigDialogComponent);
-  }
-
-  openLogin() {
-    this.dialog.open(LoginDialogComponent);
-  }
-
-  openClusterAdmin() {
-    this.dialog.open(ClusterAdminDialogComponent, {
-      width: '800px'
-    });
   }
 
   /**

--- a/packages/app/src/app/projects/projects-list/projects-list.component.html
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.html
@@ -116,3 +116,4 @@
     </mat-paginator>
   </div>
 </div>
+<app-profile-button />

--- a/packages/app/src/app/projects/projects-list/projects-list.component.ts
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit, ViewChild } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
@@ -13,6 +12,7 @@ import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/p
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 import { Project } from '@reefguide/db';
 import {
   BehaviorSubject,
@@ -20,14 +20,12 @@ import {
   debounceTime,
   distinctUntilChanged,
   map,
-  Observable,
-  startWith,
-  switchMap,
-  merge,
-  EMPTY
+  Observable
 } from 'rxjs';
 import { WebApiService } from '../../../api/web-api.service';
+import { ProfileButtonComponent } from '../../user/profile-button/profile-button.component';
 import { CreateProjectDialogComponent } from '../create-project-dialog/create-project-dialog.component';
+import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'app-projects-list',
@@ -45,7 +43,8 @@ import { CreateProjectDialogComponent } from '../create-project-dialog/create-pr
     MatPaginatorModule,
     MatProgressSpinnerModule,
     MatRadioModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    ProfileButtonComponent
   ],
   templateUrl: './projects-list.component.html',
   styleUrls: ['./projects-list.component.scss']

--- a/packages/app/src/app/user/profile-button/profile-button.component.html
+++ b/packages/app/src/app/user/profile-button/profile-button.component.html
@@ -1,0 +1,33 @@
+@let user = user$ | async;
+@let isAdmin = isAdmin$ | async;
+@if (user) {
+  <button
+    class="profile-button"
+    mat-mini-fab
+    [matMenuTriggerFor]="profileMenu"
+    [matTooltip]="user?.email"
+    matTooltipPosition="left"
+  >
+    <mat-icon>account_circle</mat-icon>
+  </button>
+  <mat-menu #profileMenu="matMenu">
+    <button mat-menu-item (click)="onConfigClick()">
+      <mat-icon>settings</mat-icon>
+      <span>Settings</span>
+    </button>
+    <button mat-menu-item (click)="onLogoutClick()">
+      <mat-icon>logout</mat-icon>
+      <span>Logout</span>
+    </button>
+    @if (isAdmin) {
+      <button mat-menu-item (click)="onAdminPanelClick()">
+        <mat-icon>supervised_user_circle</mat-icon>
+        <span>Manage Users</span>
+      </button>
+      <button mat-menu-item (click)="onClusterAdminClick()">
+        <mat-icon>dns</mat-icon>
+        <span>Manage Cluster</span>
+      </button>
+    }
+  </mat-menu>
+}

--- a/packages/app/src/app/user/profile-button/profile-button.component.scss
+++ b/packages/app/src/app/user/profile-button/profile-button.component.scss
@@ -1,0 +1,5 @@
+.profile-button {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}

--- a/packages/app/src/app/user/profile-button/profile-button.component.spec.ts
+++ b/packages/app/src/app/user/profile-button/profile-button.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProfileButtonComponent } from './profile-button.component';
+
+describe('ProfileButtonComponent', () => {
+  let component: ProfileButtonComponent;
+  let fixture: ComponentFixture<ProfileButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileButtonComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProfileButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/user/profile-button/profile-button.component.spec.ts
+++ b/packages/app/src/app/user/profile-button/profile-button.component.spec.ts
@@ -9,8 +9,7 @@ describe('ProfileButtonComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProfileButtonComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileButtonComponent);
     component = fixture.componentInstance;

--- a/packages/app/src/app/user/profile-button/profile-button.component.ts
+++ b/packages/app/src/app/user/profile-button/profile-button.component.ts
@@ -1,0 +1,54 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { ClusterAdminDialogComponent } from '../../admin/cluster/ClusterAdminDialog.component';
+import { AdminPanelComponent } from '../../admin/user-panel/user-panel.component';
+import { AuthService } from '../../auth/auth.service';
+import { ConfigDialogComponent } from '../../location-selection/config-dialog/config-dialog.component';
+
+@Component({
+  selector: 'app-profile-button',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    MatTooltipModule,
+    MatDialogModule
+  ],
+  templateUrl: './profile-button.component.html',
+  styleUrl: './profile-button.component.scss'
+})
+export class ProfileButtonComponent {
+  private authService = inject(AuthService);
+  private dialog = inject(MatDialog);
+  public isAdmin$ = this.authService.isAdmin();
+  public user$ = this.authService.user$;
+
+  onConfigClick(): void {
+    this.dialog.open(ConfigDialogComponent);
+  }
+
+  onLogoutClick(): void {
+    if (this.authService) {
+      this.authService.logout();
+    }
+  }
+
+  onAdminPanelClick(): void {
+    this.dialog.open(AdminPanelComponent, {
+      width: '800px'
+    });
+  }
+
+  onClusterAdminClick(): void {
+    this.dialog.open(ClusterAdminDialogComponent, {
+      width: '800px'
+    });
+  }
+}

--- a/packages/infra/src/infra.ts
+++ b/packages/infra/src/infra.ts
@@ -239,7 +239,7 @@ export class ReefguideStack extends cdk.Stack {
                   '--project=@app',
                   '-t',
                   'auto',
-                  `-J`,
+                  '-J',
                   reefguide.sysimage.sysimagePath,
                   '--sysimage-native-code=yes',
                   '-e',


### PR DESCRIPTION
Moves the profile button into a standalone component, and updates the projects list and location selection components to use it. Updates the shouldRenderBackground function to only render if the user is authorised.