### PR TITLE
feat: only query my jobs in site selection

### DIFF
--- a/packages/app/src/api/web-api.service.ts
+++ b/packages/app/src/api/web-api.service.ts
@@ -14,6 +14,7 @@ import {
   JobDetailsResponse,
   ListJobsQuery,
   ListJobsResponse,
+  ListMyJobsQuery,
   ListUserLogsResponse,
   LoginResponse,
   ProfileResponse,
@@ -182,8 +183,14 @@ export class WebApiService {
     });
   }
 
-  listJobs(query?: ListJobsQuery): Observable<ListJobsResponse> {
+  listAllJobs(query?: ListJobsQuery): Observable<ListJobsResponse> {
     return this.http.get<ListJobsResponse>(`${this.base}/jobs`, {
+      params: query
+    });
+  }
+
+  listMyJobs(query?: ListMyJobsQuery): Observable<ListJobsResponse> {
+    return this.http.get<ListJobsResponse>(`${this.base}/jobs/mine`, {
       params: query
     });
   }

--- a/packages/app/src/app/jobs/jobs-manager.service.ts
+++ b/packages/app/src/app/jobs/jobs-manager.service.ts
@@ -109,10 +109,13 @@ export class JobsManagerService {
    */
   refresh() {
     // TODO PENDING or IN-PROGRESS
-    // TODO update API to support only my jobs, if admin, you'll see everyone's jobs
-    this.webApi.listJobs({ status: 'PENDING' }).subscribe(jobs => {
-      this.addExistingJobs(jobs);
-    });
+    this.webApi
+      .listMyJobs({
+        status: 'PENDING'
+      })
+      .subscribe(jobs => {
+        this.addExistingJobs(jobs);
+      });
   }
 
   /**

--- a/packages/app/src/app/jobs/jobs-table/jobs-table.component.ts
+++ b/packages/app/src/app/jobs/jobs-table/jobs-table.component.ts
@@ -40,7 +40,7 @@ export class JobsTableComponent {
   @ViewChild(MatSort) sort!: MatSort;
 
   constructor() {
-    this.jobs$ = this.api.listJobs();
+    this.jobs$ = this.api.listAllJobs();
 
     this.jobs$.subscribe(resp => {
       this.dataSource.data = resp.jobs;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -193,9 +193,17 @@ export type JobRequest = z.infer<typeof jobRequestSchema>;
 
 // List Jobs Query
 export const listJobsSchema = z.object({
-  status: z.nativeEnum(JobStatus).optional()
+  status: z.nativeEnum(JobStatus).optional(),
+  // If the user is an admin, they can list others' jobs
+  userId: z.string().optional()
 });
 export type ListJobsQuery = z.infer<typeof listJobsSchema>;
+
+// List my Jobs Query
+export const listMyJobsSchema = z.object({
+  status: z.nativeEnum(JobStatus).optional()
+});
+export type ListMyJobsQuery = z.infer<typeof listMyJobsSchema>;
 
 // List Jobs Response (uses base job schema without relations)
 export const listJobsResponseSchema = z.object({

--- a/packages/web-api/src/jobs/routes.ts
+++ b/packages/web-api/src/jobs/routes.ts
@@ -10,6 +10,8 @@ import {
   JobDetailsResponse,
   ListJobsResponse,
   listJobsSchema,
+  ListMyJobsQuery,
+  listMyJobsSchema,
   PollJobsResponse,
   pollJobsSchema,
   submitResultSchema
@@ -59,6 +61,12 @@ router.post(
   }
 );
 
+/**
+ * List all jobs
+ * - Admins can specify a userId to list jobs for that user
+ * - Non-admins can only list their own jobs
+ * - Can filter by status
+ */
 router.get(
   '/',
   processRequest({
@@ -69,8 +77,44 @@ router.get(
   async (req, res: Response<ListJobsResponse>) => {
     if (!req.user) throw new UnauthorizedException();
 
+    // If the user is an admin, they can specify a userId to list jobs for that
+    // user
+    const customUserId = req.query.userId ? parseInt(req.query.userId) : undefined;
     const isAdmin = userIsAdmin(req.user);
-    const userId = isAdmin ? undefined : req.user.id;
+    if (!isAdmin && customUserId !== req.user.id) {
+      throw new UnauthorizedException(
+        'Non-admin users cannot specify a userId other than their own.'
+      );
+    }
+    const userId = customUserId ?? (isAdmin ? undefined : req.user.id);
+    const status = req.query.status as JobStatus | undefined;
+
+    const { jobs, total } = await jobService.listJobs({
+      userId,
+      status
+    });
+
+    res.json({ jobs, total });
+  }
+);
+
+/**
+ * List jobs for the authenticated user
+ * - Can filter by status
+ * - Only returns jobs created by the authenticated user
+ */
+router.get(
+  '/mine',
+  processRequest({
+    query: listMyJobsSchema
+  }),
+  passport.authenticate('jwt', { session: false }),
+  assertUserHasRoleMiddleware({ sufficientRoles: ['ANALYST'] }),
+  async (req, res: Response<ListJobsResponse>) => {
+    if (!req.user) throw new UnauthorizedException();
+
+    // Only list jobs for the authenticated user
+    const userId = req.user.id;
     const status = req.query.status as JobStatus | undefined;
 
     const { jobs, total } = await jobService.listJobs({

--- a/packages/web-api/src/jobs/routes.ts
+++ b/packages/web-api/src/jobs/routes.ts
@@ -10,7 +10,6 @@ import {
   JobDetailsResponse,
   ListJobsResponse,
   listJobsSchema,
-  ListMyJobsQuery,
   listMyJobsSchema,
   PollJobsResponse,
   pollJobsSchema,
@@ -81,7 +80,7 @@ router.get(
     // user
     const customUserId = req.query.userId ? parseInt(req.query.userId) : undefined;
     const isAdmin = userIsAdmin(req.user);
-    if (!isAdmin && customUserId !== req.user.id) {
+    if (!isAdmin && customUserId !== undefined && customUserId !== req.user.id) {
       throw new UnauthorizedException(
         'Non-admin users cannot specify a userId other than their own.'
       );


### PR DESCRIPTION
Closes #28 

Adds /mine endpoint to list only current users jobs. 

Also adds optional userId property to the main list all. This is only allowed to be NOT the current userId if the user is an admin.