### PR TITLE
Low-High tide criteria

### DIFF
--- a/packages/app/src/api/web-api.service.ts
+++ b/packages/app/src/api/web-api.service.ts
@@ -15,6 +15,7 @@ import {
   ListJobsQuery,
   ListJobsResponse,
   ListMyJobsQuery,
+  ListRegionsResponse,
   ListUserLogsResponse,
   LoginResponse,
   ProfileResponse,
@@ -323,6 +324,10 @@ export class WebApiService {
         cluster: true
       }
     ];
+  }
+
+  getRegions(): Observable<ListRegionsResponse> {
+    return this.http.get<ListRegionsResponse>(`${this.base}/admin/regions`);
   }
 
   getRegionCriteria(region: string): Observable<CriteriaRangeOutput> {

--- a/packages/app/src/app/location-selection/reef-guide-config.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-config.service.ts
@@ -26,13 +26,6 @@ const configVarGetters: Partial<Record<keyof StoredConfig, (val: string) => any>
   enableCOGBlob: getBoolean
 };
 
-export const ALL_REGIONS = [
-  'Townsville-Whitsunday',
-  'Cairns-Cooktown',
-  'Mackay-Capricorn',
-  'FarNorthern'
-];
-
 @Injectable({
   providedIn: 'root'
 })

--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -450,16 +450,20 @@ export class ReefGuideMapService {
 
   /**
    * Show this criteria layer and hide others.
-   * @param criteria layer id
+   * @param criteriaId layer id
    * @param show show/hide layer
    */
-  showCriteriaLayer(criteria: string, show = true) {
+  showCriteriaLayer(criteriaId: string, show = true) {
     const criteriaLayerGroup = this.criteriaLayerGroup();
     if (criteriaLayerGroup) {
       criteriaLayerGroup.setVisible(true);
       for (let id in this.criteriaLayers) {
         const criteriaLayer = this.criteriaLayers[id];
-        criteriaLayer?.visible.set(id === criteria && show);
+        criteriaLayer?.visible.set(id === criteriaId && show);
+      }
+
+      if (!(criteriaId in this.criteriaLayers)) {
+        console.warn(`No "${criteriaId}" criteria layer`);
       }
     }
   }

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
@@ -1,11 +1,12 @@
 @let sliderDefs = enabledSliderDefs();
+@let regions = regions$ | async;
 <div class="scrollable">
   <form [formGroup]="form">
     <mat-form-field class="region-select">
       <mat-label>Region</mat-label>
       <mat-select formControlName="region">
-        @for (region of regions; track region) {
-          <mat-option [value]="region">{{ region }}</mat-option>
+        @for (region of regions; track region.name) {
+          <mat-option [value]="region.name">{{ region.display_name }}</mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
@@ -15,7 +15,10 @@
         @for (sliderDef of sliderDefs; track sliderDef.criteria.id) {
           @let c = sliderDef.criteria;
           @let slider = sliderDef.slider;
-          @let criteriaLayer = slider.criteriaLayerId !== undefined ? mapService.criteriaLayers[slider.criteriaLayerId] : undefined;
+          @let criteriaLayer =
+            slider.criteriaLayerId !== undefined
+              ? mapService.criteriaLayers[slider.criteriaLayerId]
+              : undefined;
           @let visible = criteriaLayer?.visible();
           @let loading = criteriaLayer?.loading();
           @let progress = criteriaLayer?.loadingProgress();
@@ -31,9 +34,7 @@
               }
               @if (visible != null) {
                 @if (slider.previewAlert) {
-                  <mat-icon
-                    [matTooltip]="slider.previewAlert"
-                    matTooltipPosition="below">
+                  <mat-icon [matTooltip]="slider.previewAlert" matTooltipPosition="below">
                     warning
                   </mat-icon>
                 }
@@ -47,12 +48,7 @@
               }
             </div>
             <p class="subtitle mat-body-small">{{ c.display_subtitle }}</p>
-            <mat-slider
-              [min]="slider.min"
-              [max]="slider.max"
-              discrete="true"
-              [step]="slider.step"
-            >
+            <mat-slider [min]="slider.min" [max]="slider.max" discrete="true" [step]="slider.step">
               <input
                 matSliderStartThumb
                 [formControlName]="`${c.payload_property_prefix}min`"

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
@@ -1,4 +1,4 @@
-@let criteriaRanges = enabledRegionCriteriaRanges();
+@let sliderDefs = enabledSliderDefs();
 <div class="scrollable">
   <form [formGroup]="form">
     <mat-form-field class="region-select">
@@ -9,10 +9,12 @@
         }
       </mat-select>
     </mat-form-field>
-    @if (criteriaRanges) {
+    @if (sliderDefs) {
       <div formGroupName="criteria">
-        @for (c of criteriaRanges; track c.id) {
-          @let criteriaLayer = mapService.criteriaLayers[c.id];
+        @for (sliderDef of sliderDefs; track sliderDef.criteria.id) {
+          @let c = sliderDef.criteria;
+          @let slider = sliderDef.slider;
+          @let criteriaLayer = slider.criteriaLayerId !== undefined ? mapService.criteriaLayers[slider.criteriaLayerId] : undefined;
           @let visible = criteriaLayer?.visible();
           @let loading = criteriaLayer?.loading();
           @let progress = criteriaLayer?.loadingProgress();
@@ -27,10 +29,17 @@
                 ></mat-progress-spinner>
               }
               @if (visible != null) {
+                @if (slider.previewAlert) {
+                  <mat-icon
+                    [matTooltip]="slider.previewAlert"
+                    matTooltipPosition="below">
+                    warning
+                  </mat-icon>
+                }
                 <button
                   mat-icon-button
                   class="visibility"
-                  (click)="mapService.showCriteriaLayer(c.id, !visible)"
+                  (click)="mapService.showCriteriaLayer(slider.criteriaLayerId, !visible)"
                 >
                   <mat-icon>{{ visible ? 'visibility' : 'visibility_off' }}</mat-icon>
                 </button>
@@ -38,19 +47,21 @@
             </div>
             <p class="subtitle mat-body-small">{{ c.display_subtitle }}</p>
             <mat-slider
-              [min]="c.slider_min"
-              [max]="c.slider_max"
+              [min]="slider.min"
+              [max]="slider.max"
               discrete="true"
-              [step]="c.slider_step"
+              [step]="slider.step"
             >
               <input
                 matSliderStartThumb
                 [formControlName]="`${c.payload_property_prefix}min`"
+                [matTooltip]="c.min_tooltip"
                 (blur)="onBlurSlider(c.id)"
               />
               <input
                 matSliderEndThumb
                 [formControlName]="`${c.payload_property_prefix}max`"
+                [matTooltip]="c.max_tooltip"
                 (blur)="onBlurSlider(c.id)"
               />
             </mat-slider>

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
@@ -1,4 +1,4 @@
-@let criteriaRanges = regionCriteriaRanges();
+@let criteriaRanges = enabledRegionCriteriaRanges();
 <div class="scrollable">
   <form [formGroup]="form">
     <mat-form-field class="region-select">

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.html
@@ -56,13 +56,13 @@
                 matSliderStartThumb
                 [formControlName]="`${c.payload_property_prefix}min`"
                 [matTooltip]="c.min_tooltip"
-                (blur)="onBlurSlider(c.id)"
+                (blur)="onBlurSlider(sliderDef)"
               />
               <input
                 matSliderEndThumb
                 [formControlName]="`${c.payload_property_prefix}max`"
                 [matTooltip]="c.max_tooltip"
-                (blur)="onBlurSlider(c.id)"
+                (blur)="onBlurSlider(sliderDef)"
               />
             </mat-slider>
           </div>

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
@@ -14,12 +14,12 @@ import { CriteriaPayloads, SiteSuitabilityCriteria } from '../reef-guide-api.typ
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
-import { ALL_REGIONS } from '../reef-guide-config.service';
 import { MatSelectModule } from '@angular/material/select';
 import {
   catchError,
   combineLatestWith,
   EMPTY,
+  map,
   Observable,
   skip,
   startWith,
@@ -33,6 +33,8 @@ import { CriteriaRangeOutput } from '@reefguide/types';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { LayerController } from '../../map/openlayers-model';
+import { retryHTTPErrors } from '../../../util/http-util';
+import { AsyncPipe } from '@angular/common';
 
 type SliderDef = {
   // original criteria definition from API
@@ -68,7 +70,8 @@ type SliderDef = {
     ReactiveFormsModule,
     MatSelectModule,
     MatTooltip,
-    MatProgressSpinner
+    MatProgressSpinner,
+    AsyncPipe
   ],
   templateUrl: './selection-criteria.component.html',
   styleUrl: './selection-criteria.component.scss'
@@ -78,7 +81,10 @@ export class SelectionCriteriaComponent {
   private readonly formBuilder = inject(FormBuilder);
   readonly mapService = inject(ReefGuideMapService);
 
-  regions = ALL_REGIONS;
+  regions$ = this.api.getRegions().pipe(
+    retryHTTPErrors(3),
+    map(resp => resp.regions)
+  );
 
   sliderDefs = signal<SliderDef[] | undefined>(undefined);
   enabledSliderDefs = computed(() => {

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
@@ -33,21 +33,26 @@ import { CriteriaRangeOutput } from '@reefguide/types';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
-// add app properties, but keep original from API readonly
-type CriteriaRangeOutput2 = Readonly<CriteriaRangeOutput[string]> & {
-  // slider code may change these, min/max are rounded
-  slider_min: number;
-  slider_max: number;
-  // default values may differ due to negativeFlippedCriteria
-  slider_default_min: number;
-  slider_default_max: number;
-  // currently determined by app code, though could define server-side
-  slider_step: number;
-  // user is not allowed to set this criteria via the UI.
-  disabled: boolean;
+type SliderDef = {
+  // original criteria definition from API
+  readonly criteria: Readonly<CriteriaRangeOutput[string]>;
+  slider: {
+    // slider code may change these, min/max are rounded
+    min: number;
+    max: number;
+    // default values may differ due to negativeFlippedCriteria
+    default_min: number;
+    default_max: number;
+    // currently determined by app code, though could define server-side
+    step: number;
+    // user is not allowed to set this criteria via the UI.
+    disabled: boolean;
+    // criteria layer this slider pixel-filters
+    criteriaLayerId: string;
+    // warning message during slider pixel filtering
+    previewAlert?: string;
+  };
 };
-
-type CriteriaRangeList = Array<CriteriaRangeOutput2>;
 
 @Component({
   selector: 'app-selection-criteria',
@@ -80,32 +85,21 @@ export class SelectionCriteriaComponent {
 
   regions = ALL_REGIONS;
 
-  regionCriteriaRanges = signal<CriteriaRangeList | undefined>(undefined);
-  enabledRegionCriteriaRanges = computed(() =>
-    this.regionCriteriaRanges()?.filter(c => !c.disabled)
-  );
-
-  regionCriteriaRangeMap = computed(() => {
-    const list = this.regionCriteriaRanges();
-    if (list) {
-      return list.reduce(
-        (acc, c) => {
-          acc[c.id] = c;
-          return acc;
-        },
-        {} as Record<string, CriteriaRangeOutput2>
-      );
-    } else {
-      return undefined;
-    }
-  });
+  sliderDefs = signal<SliderDef[] | undefined>(undefined);
+  enabledSliderDefs = computed(() => this.sliderDefs()?.filter(s => !s.slider.disabled));
 
   enableSiteSuitability = signal(true);
 
   /**
-   * IDs of Criteria that are flipped to positive values for the UI.
+   * Criteria ID that is currently pixel-filtering.
    */
-  negativeFlippedCriteria = new Set(['Depth']);
+  previewingCriteriaFilter = signal<string | undefined>(undefined);
+
+  /**
+   * IDs of Criteria that are flipped to positive values for the UI.
+   * TODO move to ReefGuide.ASSESSMENT_CRITERIA
+   */
+  negativeFlippedCriteria = new Set(['Depth', 'LowTide', 'HighTide', '_LowHighTideDepth']);
 
   form: FormGroup;
 
@@ -127,7 +121,7 @@ export class SelectionCriteriaComponent {
       .pipe(
         tap(x => {
           // TODO need loading indicator?
-          this.regionCriteriaRanges.set(undefined);
+          this.sliderDefs.set(undefined);
         }),
         switchMap(region =>
           this.api.getRegionCriteria(region).pipe(
@@ -153,58 +147,111 @@ export class SelectionCriteriaComponent {
   private buildCriteriaFormGroup(regionCriteria: CriteriaRangeOutput) {
     this.reset$.next();
 
+    const enableLowHighDepthMode =
+      'LowTide' in regionCriteria && 'HighTide' in regionCriteria && 'Depth' in regionCriteria;
+
+    const availableCriteria = Object.values(regionCriteria);
+
     // TODO order?
-    const regionCriteriaRanges = Object.values(regionCriteria) as CriteriaRangeList;
+    const regionCriteriaRanges: SliderDef[] = [];
+
+    // this a virtual criteria that will set
+    // in the future may add feature to toggle between
+    // Depth, LowTide, HighTide, and this Low-High mode.
+    if (enableLowHighDepthMode) {
+      const depthCriteria = regionCriteria['Depth']!;
+      // Use Depth params with a fe changes.
+      availableCriteria.push({
+        ...depthCriteria,
+        id: '_LowHighTideDepth',
+        display_title: 'Low-tide to High-tide depth',
+        display_subtitle: 'Minimum depth at low tide to maximum depth at high tide',
+        payload_property_prefix: '_low_high_tide_depth_',
+        min_tooltip: 'Minimum depth at low tide',
+        max_tooltip: 'Maximum depth at high tide'
+      });
+
+      // replaces Depth slider
+      this.disabledCriteria.add('Depth');
+    }
 
     // formBuilder definitions for 'criteria' group
     const criteriaControlDefs: Record<string, any> = {};
 
-    for (const c of regionCriteriaRanges) {
-      const { min_val, max_val, default_min_val, default_max_val } = c;
-      if (default_min_val < min_val) {
-        console.warn(`criteria ${c.id} default_min_val=${default_min_val} < min_val=${min_val}`);
-      }
+    for (const c of availableCriteria) {
+      const sliderDef = this.createSliderDef(c);
+      regionCriteriaRanges.push(sliderDef);
 
-      if (default_max_val > max_val) {
-        console.warn(`criteria ${c.id} default_max_val=${default_max_val} > max_val=${max_val}`);
-      }
-
-      c.disabled = this.disabledCriteria.has(c.id);
-
-      // this feature is for criteria like Depth
-      // round the min/max outward, otherwise the slider step values will be long
-      // floating point numbers that are visible to user on slider thumb.
-      // Note that values will be clamped by getCriteriaPayloads
-      if (this.negativeFlippedCriteria.has(c.id)) {
-        c.slider_min = Math.floor(-max_val);
-        c.slider_max = Math.ceil(-min_val);
-        c.slider_default_min = -default_max_val;
-        c.slider_default_max = -default_min_val;
-      } else {
-        c.slider_min = Math.floor(min_val);
-        c.slider_max = Math.ceil(max_val);
-        c.slider_default_min = default_min_val;
-        c.slider_default_max = default_max_val;
-      }
-
-      // use step 1 for large ranges, step 0.1 for smaller. (40 is arbitrary)
-      const diff = c.max_val - c.min_val;
-      c.slider_step = diff > 40 ? 1 : diff > 4 ? 0.1 : 0.02;
-
-      if (!c.disabled) {
+      if (!sliderDef.slider.disabled) {
         // ensure that default values are not outside the slider range.
-        const minValue = Math.max(c.slider_min, c.slider_default_min);
-        const maxValue = Math.min(c.slider_max, c.slider_default_max);
+        const minValue = Math.max(sliderDef.slider.min, sliderDef.slider.default_min);
+        const maxValue = Math.min(sliderDef.slider.max, sliderDef.slider.default_max);
 
-        criteriaControlDefs[`${c.payload_property_prefix}min`] = [minValue];
-        criteriaControlDefs[`${c.payload_property_prefix}max`] = [maxValue];
+        criteriaControlDefs[`${sliderDef.criteria.payload_property_prefix}min`] = [minValue];
+        criteriaControlDefs[`${sliderDef.criteria.payload_property_prefix}max`] = [maxValue];
       }
     }
 
     const formGroup = this.formBuilder.group(criteriaControlDefs);
     this.form.setControl('criteria', formGroup);
 
-    this.regionCriteriaRanges.set(regionCriteriaRanges);
+    this.sliderDefs.set(regionCriteriaRanges);
+  }
+
+  private createSliderDef(criteria: CriteriaRangeOutput[string]): SliderDef {
+    const { id, min_val, max_val, default_min_val, default_max_val } = criteria;
+
+    if (default_min_val < min_val) {
+      console.warn(`criteria ${id} default_min_val=${default_min_val} < min_val=${min_val}`);
+    }
+
+    if (default_max_val > max_val) {
+      console.warn(`criteria ${id} default_max_val=${default_max_val} > max_val=${max_val}`);
+    }
+
+    // this feature is for criteria like Depth
+    // round the min/max outward, otherwise the slider step values will be long
+    // floating point numbers that are visible to user on slider thumb.
+    // Note that values will be clamped by getCriteriaPayloads
+    let slider_min, slider_max, slider_default_min, slider_default_max;
+    if (this.negativeFlippedCriteria.has(id)) {
+      slider_min = Math.floor(-max_val);
+      slider_max = Math.ceil(-min_val);
+      slider_default_min = -default_max_val;
+      slider_default_max = -default_min_val;
+    } else {
+      slider_min = Math.floor(min_val);
+      slider_max = Math.ceil(max_val);
+      slider_default_min = default_min_val;
+      slider_default_max = default_max_val;
+    }
+
+    const diff = max_val - min_val;
+    // use step 1 for large ranges, step 0.1 for smaller. (40 is arbitrary)
+    const slider_step = diff > 40 ? 1 : diff > 4 ? 0.1 : 0.02;
+
+    let previewAlert: string | undefined;
+    let criteriaLayerId = criteria.id;
+
+    if (id === '_LowHighTideDepth') {
+      // Low-High Tide Depth is a virtual criteria, use Depth layer
+      criteriaLayerId = 'Depth';
+      previewAlert = 'Map preview uses MSL depth instead of tide depth';
+    }
+
+    return {
+      criteria,
+      slider: {
+        disabled: this.disabledCriteria.has(id),
+        step: slider_step,
+        min: slider_min,
+        max: slider_max,
+        default_min: slider_default_min,
+        default_max: slider_default_max,
+        criteriaLayerId,
+        previewAlert
+      }
+    };
   }
 
   /**
@@ -212,25 +259,27 @@ export class SelectionCriteriaComponent {
    * Sets layer visible (exclusive to other criteria layers) on min|max change
    */
   private setupLayerPixelFiltering() {
-    const regionCriteriaRanges = this.regionCriteriaRanges();
+    const slidersDefs = this.enabledSliderDefs();
     const formGroup = this.form.get('criteria');
-    if (!regionCriteriaRanges || !formGroup) {
+    if (!slidersDefs || !formGroup) {
       return;
     }
-    for (const c of regionCriteriaRanges) {
-      const layerController = this.mapService.criteriaLayers[c.id];
+    for (const def of slidersDefs) {
+      const { criteria, slider } = def;
+      const layerId = slider.criteriaLayerId;
+
+      const layerController = layerId ? this.mapService.criteriaLayers[layerId] : undefined;
       if (layerController) {
-        const { slider_min, slider_max } = c;
-        const range = slider_max - slider_min;
-        const minKey = `${c.payload_property_prefix}min`;
-        const maxKey = `${c.payload_property_prefix}max`;
+        const range = slider.max - slider.min;
+        const minKey = `${criteria.payload_property_prefix}min`;
+        const maxKey = `${criteria.payload_property_prefix}max`;
 
         const min$ = formGroup
           .get(minKey)!
-          .valueChanges.pipe(startWith(c.slider_default_min)) as Observable<number>;
+          .valueChanges.pipe(startWith(slider.default_min)) as Observable<number>;
         const max$ = formGroup
           .get(maxKey)!
-          .valueChanges.pipe(startWith(c.slider_default_max)) as Observable<number>;
+          .valueChanges.pipe(startWith(slider.default_max)) as Observable<number>;
 
         min$
           .pipe(combineLatestWith(max$))
@@ -238,13 +287,14 @@ export class SelectionCriteriaComponent {
           .subscribe(([min, max]) => {
             if (!layerController.visible()) {
               layerController.visible.set(true);
-              this.mapService.showCriteriaLayer(c.id);
+              this.mapService.showCriteriaLayer(layerId);
             }
 
             // normalized 0:1
-            const nMin = (min - slider_min) / range;
-            const nMax = (max - slider_min) / range;
+            const nMin = (min - slider.min) / range;
+            const nMax = (max - slider.min) / range;
             layerController.filterLayerPixels(nMin, nMax);
+            this.previewingCriteriaFilter.set(criteria.id);
           });
       }
     }
@@ -256,7 +306,7 @@ export class SelectionCriteriaComponent {
    */
   getCriteriaPayloads(): CriteriaPayloads {
     const formValue = this.form.value;
-    const criteriaRanges = this.enabledRegionCriteriaRanges()!;
+    const sliderDefs = this.enabledSliderDefs()!;
 
     if (!this.form.valid) {
       // this causes required form inputs to show error state
@@ -264,50 +314,44 @@ export class SelectionCriteriaComponent {
       throw new Error('Form invalid!');
     }
 
-    const criteria: Record<string, number | undefined> = {
+    // form values for the criteria group.
+    const formValues: Record<string, number | undefined> = {
       ...formValue.criteria
     };
 
     // fix values of negative-flipped criteria
-    for (const c of criteriaRanges) {
-      const isFlipped = this.negativeFlippedCriteria.has(c.id);
-      const minKey = `${c.payload_property_prefix}min`;
-      const maxKey = `${c.payload_property_prefix}max`;
+    for (const sliderDef of sliderDefs) {
+      const { criteria } = sliderDef;
+      const isFlipped = this.negativeFlippedCriteria.has(criteria.id);
+      const minKey = `${criteria.payload_property_prefix}min`;
+      const maxKey = `${criteria.payload_property_prefix}max`;
 
       // convert back to un-flipped criteria coordinates if needed
-      const minValue = isFlipped ? -criteria[maxKey]! : criteria[minKey]!;
-      const maxValue = isFlipped ? -criteria[minKey]! : criteria[maxKey]!;
+      const minValue = isFlipped ? -formValues[maxKey]! : formValues[minKey]!;
+      const maxValue = isFlipped ? -formValues[minKey]! : formValues[maxKey]!;
 
       // clamp values since could be outside range due to slider floor(min), ceil(max)
-      criteria[minKey] = Math.max(minValue, c.min_val);
-      criteria[maxKey] = Math.min(maxValue, c.max_val);
+      formValues[minKey] = Math.max(minValue, criteria.min_val);
+      formValues[maxKey] = Math.min(maxValue, criteria.max_val);
+
+      if (criteria.id === '_LowHighTideDepth') {
+        // Low-High tide mode
+        // FUTURE Depth could toggle modes between LowTide, HighTide, MSL, and Low-High.
+        // in this context, depth is already negative-flipped so more negative is deeper
+
+        // depth_max is shallowest (least negative)
+        formValues['low_tide_max'] = formValues['_low_high_tide_depth_max'];
+        // omit low_tide_min, ReefGuideWorker will default to criteria bounds min.
+
+        // depth_min is deepest (most negative)
+        formValues['high_tide_min'] = formValues['_low_high_tide_depth_min'];
+        // omit high_tide_max, ReefGuideWorker will default to criteria bounds max.
+
+        // replace the virtual properties
+        delete formValues['_low_high_tide_depth_min'];
+        delete formValues['_low_high_tide_depth_max'];
+      }
     }
-
-    const criteriaRangeMap = this.regionCriteriaRangeMap()!;
-    const lowTideCriteria = criteriaRangeMap['LowTide'];
-    if (lowTideCriteria === undefined) {
-      throw new Error('LowTide criteria missing!');
-    }
-    const highTideCriteria = criteriaRangeMap['HighTide'];
-    if (highTideCriteria === undefined) {
-      throw new Error('HighTide criteria missing!');
-    }
-
-    // Low-High tide mode
-    // FUTURE Depth could toggle modes between LowTide, HighTide, MSL, and Low-High.
-    // in this context, depth is already negative-flipped so more negative is deeper
-
-    // depth_max is shallowest (least negative)
-    criteria['low_tide_max'] = criteria['depth_max'];
-    // omit low_tide_min, ReefGuideWorker will default to criteria bounds min.
-
-    // depth_min is deepest (most negative)
-    criteria['high_tide_min'] = criteria['depth_min'];
-    // omit high_tide_max, ReefGuideWorker will default to criteria bounds max.
-
-    // don't use MSL Depth when using Low-High tide mode.
-    delete criteria['depth_min'];
-    delete criteria['depth_max'];
 
     // console.log('criteria before/after', formValue.criteria, criteria);
 
@@ -321,7 +365,7 @@ export class SelectionCriteriaComponent {
       criteria: {
         region: formValue.region,
         reef_type: formValue.reef_type,
-        ...criteria
+        ...formValues
       },
       siteSuitability
     };
@@ -332,17 +376,18 @@ export class SelectionCriteriaComponent {
    */
   reset() {
     const criteriaFormGroup = this.form.get('criteria')!;
-    const criteriaRanges = this.regionCriteriaRanges();
-    if (criteriaRanges === undefined) {
+    const sliderDefs = this.enabledSliderDefs();
+    if (sliderDefs === undefined) {
       return;
     }
 
-    for (const c of criteriaRanges) {
+    for (const sliderDef of sliderDefs) {
+      const { criteria, slider } = sliderDef;
       // don't need to worry about negative-flipping here since we mutated min/max values
-      const minControl = criteriaFormGroup.get(`${c.payload_property_prefix}min`);
-      minControl?.setValue(c.slider_default_min);
-      const maxControl = criteriaFormGroup.get(`${c.payload_property_prefix}max`);
-      maxControl?.setValue(c.slider_default_max);
+      const minControl = criteriaFormGroup.get(`${criteria.payload_property_prefix}min`);
+      minControl?.setValue(slider.default_min);
+      const maxControl = criteriaFormGroup.get(`${criteria.payload_property_prefix}max`);
+      maxControl?.setValue(slider.default_max);
     }
 
     // TODO reset site suitability?
@@ -351,5 +396,6 @@ export class SelectionCriteriaComponent {
   onBlurSlider(criteriaId: string) {
     const lc = this.mapService.criteriaLayers[criteriaId];
     lc?.resetStyle();
+    this.previewingCriteriaFilter.set(undefined);
   }
 }

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
@@ -76,18 +76,22 @@ type SliderDef = {
 export class SelectionCriteriaComponent {
   private readonly api = inject(WebApiService);
   private readonly formBuilder = inject(FormBuilder);
-  /**
-   * Do not show sliders for these criteria ids.
-   * Turbidity data is not ready for use.
-   * LowTide and HighTide are set by the Depth slider.
-   */
-  private disabledCriteria = new Set<string>(['Turbidity', 'LowTide', 'HighTide']);
   readonly mapService = inject(ReefGuideMapService);
 
   regions = ALL_REGIONS;
 
   sliderDefs = signal<SliderDef[] | undefined>(undefined);
-  enabledSliderDefs = computed(() => this.sliderDefs()?.filter(s => !s.slider.disabled));
+  enabledSliderDefs = computed(() => {
+    const sliderDefs = this.sliderDefs();
+    if (!sliderDefs) {
+      return undefined;
+    }
+
+    const idOrder = this.criteriaOrder;
+    return sliderDefs
+      .filter(s => !s.slider.disabled)
+      .sort((a, b) => idOrder.indexOf(a.criteria.id) - idOrder.indexOf(b.criteria.id));
+  });
 
   enableSiteSuitability = signal(true);
 
@@ -95,6 +99,29 @@ export class SelectionCriteriaComponent {
    * Criteria ID that is currently pixel-filtering.
    */
   previewingCriteriaFilter = signal<string | undefined>(undefined);
+
+  /**
+   * Slider order (criteria IDs)
+   * TODO specify order in ReefGuide.ASSESSMENT_CRITERIA
+   */
+  criteriaOrder = [
+    'Depth',
+    '_LowHighTideDepth',
+    'LowTide',
+    'HighTide',
+    'Slope',
+    'Rugosity',
+    'Turbidity',
+    'WavesHs',
+    'WavesTp'
+  ];
+
+  /**
+   * Do not show sliders for these criteria ids.
+   * Turbidity data is not ready for use.
+   * LowTide and HighTide are set by the Depth slider.
+   */
+  disabledCriteria = new Set<string>(['Turbidity', 'LowTide', 'HighTide']);
 
   /**
    * IDs of Criteria that are flipped to positive values for the UI.

--- a/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
+++ b/packages/app/src/app/location-selection/selection-criteria/selection-criteria.component.ts
@@ -86,7 +86,15 @@ export class SelectionCriteriaComponent {
     map(resp => resp.regions)
   );
 
+  /**
+   * The slider definitions in the original order from the API.
+   */
   sliderDefs = signal<SliderDef[] | undefined>(undefined);
+
+  /**
+   * Slider definitions that are enabled, ordered according to criteriaOrder.
+   * The template uses this to render sliders.
+   */
   enabledSliderDefs = computed(() => {
     const sliderDefs = this.sliderDefs();
     if (!sliderDefs) {
@@ -190,7 +198,6 @@ export class SelectionCriteriaComponent {
 
     const availableCriteria = Object.values(regionCriteria);
 
-    // TODO order?
     const regionCriteriaRanges: SliderDef[] = [];
 
     // this a virtual criteria that will set

--- a/packages/app/src/app/map/openlayers-hardcoded.ts
+++ b/packages/app/src/app/map/openlayers-hardcoded.ts
@@ -1,6 +1,5 @@
 import VectorLayer from 'ol/layer/Vector';
 import { Style, Text, Fill, Stroke } from 'ol/style';
-import { Feature } from 'ol';
 
 const hideStyle = new Style();
 
@@ -33,23 +32,5 @@ export function setupGBRMPZoning(layer: VectorLayer) {
     });
   });
 
-  const source = layer.getSource();
-  if (source) {
-    // gather stats
-    const allTypes = new Set<string>();
-    const allAltZones = new Set<string>();
-    let count = 0;
-    source.on('featuresloadend', () => {
-      for (const feature of source.getFeatures()) {
-        if (feature instanceof Feature) {
-          count++;
-          // console.log('feature', feature.getProperties());
-          allAltZones.add(feature.get('ALT_ZONE'));
-          allTypes.add(feature.get('TYPE'));
-        }
-      }
-
-      console.log(`GBRMPZoning ${count} features. ALT_ZONEs, TYPEs`, allAltZones, allTypes);
-    });
-  }
+  // logFeaturesInfo(layer, ['TYPE', 'ALT_ZONE']);
 }

--- a/packages/app/src/app/map/openlayers-util.ts
+++ b/packages/app/src/app/map/openlayers-util.ts
@@ -1,6 +1,6 @@
 import Layer from 'ol/layer/Layer';
 import LayerGroup from 'ol/layer/Group';
-import { Collection } from 'ol';
+import { Collection, Feature } from 'ol';
 import BaseLayer from 'ol/layer/Base';
 import { fromEventPattern, Observable } from 'rxjs';
 import { EventsKey } from 'ol/events';
@@ -146,4 +146,40 @@ export function createTileDebugLayer(source?: DataTileSource | null): TileLayer 
       zDirection: 1
     })
   });
+}
+
+/**
+ * Log information about features as they are loaded, track distinct values of props.
+ * @param layer
+ * @param props
+ */
+export function logFeaturesInfo(layer: VectorLayer, props: string[]) {
+  const source = layer.getSource();
+  if (source) {
+    // gather stats
+    const distinctValues = new Map<string, Set<string>>();
+    for (const prop of props) {
+      distinctValues.set(prop, new Set());
+    }
+
+    let totalCount = 0;
+    source.on('featuresloadend', () => {
+      let eventCount = 0;
+      for (const feature of source.getFeatures()) {
+        if (feature instanceof Feature) {
+          eventCount++;
+          totalCount++;
+
+          for (const prop of props) {
+            const value = feature.get(prop);
+            if (value != null) {
+              distinctValues.get(prop)!.add(String(value));
+            }
+          }
+        }
+      }
+
+      console.log(`GBRMPZoning ${totalCount} features. ALT_ZONEs, TYPEs`, distinctValues);
+    });
+  }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,6 +31,9 @@ reefguide-cli --help
 
 Triggers a data specification reload job with advanced monitoring options.
 
+**IMPORTANT:** the _regional_cache_v2.dat_ file in the ReefGuide cache directory must be deleted after updates
+to `ReefGuide.ASSESSMENT_CRITERIA`. (see issue [#91](https://github.com/open-AIMS/reefguide/issues/91))
+
 ```bash
 # Basic reload with default settings
 pnpm start data-spec reload

--- a/packages/types/src/jobs.ts
+++ b/packages/types/src/jobs.ts
@@ -10,27 +10,42 @@ export const sharedCriteriaSchema = z.object({
   region: z.string().describe('Region for assessment'),
   reef_type: z.string().describe('The type of reef, slopes or flats'),
   // Criteria - all optional to match the Union{Float64,Nothing} in worker
-  depth_min: z.number().optional().describe('The depth minimum (the deeper more negative value)'),
+  depth_min: z
+    .number()
+    .optional()
+    .describe(
+      'Depth minimum (negative values, relative to sea surface where values further away from 0 is deeper)'
+    ),
   depth_max: z
     .number()
     .optional()
-    .describe('The depth maximum (the shallower less negative value)'),
+    .describe(
+      'Depth maximum (negative values, relative to sea surface where values closer to 0 is shallower)'
+    ),
   low_tide_min: z
     .number()
     .optional()
-    .describe('The deepest depth at low tide (the more negative value)'),
+    .describe(
+      'Low tide minimum (negative values, relative to sea surface where values further away from 0 is deeper)'
+    ),
   low_tide_max: z
     .number()
     .optional()
-    .describe('The shallowest depth at low tide (the less negative value)'),
+    .describe(
+      'Low tide maximum (negative values, relative to sea surface where values closer to 0 is shallower)'
+    ),
   high_tide_min: z
     .number()
     .optional()
-    .describe('The deepest depth at high tide (the more negative value)'),
+    .describe(
+      'High tide minimum (negative values, relative to sea surface where values further away from 0 is deeper)'
+    ),
   high_tide_max: z
     .number()
     .optional()
-    .describe('The shallowest depth at high tide (the less negative value)'),
+    .describe(
+      'High tide maximum (negative values, relative to sea surface where values closer to 0 is shallower)'
+    ),
   slope_min: z.number().optional().describe('The slope range (min)'),
   slope_max: z.number().optional().describe('The slope range (max)'),
   rugosity_min: z.number().optional().describe('The rugosity range (min)'),

--- a/packages/types/src/jobs.ts
+++ b/packages/types/src/jobs.ts
@@ -15,6 +15,22 @@ export const sharedCriteriaSchema = z.object({
     .number()
     .optional()
     .describe('The depth maximum (the shallower less negative value)'),
+  low_tide_min: z
+    .number()
+    .optional()
+    .describe('The deepest depth at low tide (the more negative value)'),
+  low_tide_max: z
+    .number()
+    .optional()
+    .describe('The shallowest depth at low tide (the less negative value)'),
+  high_tide_min: z
+    .number()
+    .optional()
+    .describe('The deepest depth at high tide (the more negative value)'),
+  high_tide_max: z
+    .number()
+    .optional()
+    .describe('The shallowest depth at high tide (the less negative value)'),
   slope_min: z.number().optional().describe('The slope range (min)'),
   slope_max: z.number().optional().describe('The slope range (max)'),
   rugosity_min: z.number().optional().describe('The rugosity range (min)'),


### PR DESCRIPTION
#74

When LowTide, HighTide, Depth all available, the Depth slider is replaced by a Low to High Tide slider, which sets `low_tide_max` and `high_tide_min`

<img width="448" height="222" alt="image" src="https://github.com/user-attachments/assets/5f8381e8-3411-4ee7-9f8f-03fbe12ed78d" />

* use regions defined by API
* improve slider definition code
* Low-Hide Tide Depth uses the MSL depth layer, show a warning about this (tooltip on icon)
* hide criteria layer made visible by slider on blur
* document `ASSESSMENT_CRITERIA` data-spec reload issue
* order the criteria (hardcoded in app code for now)

---

Requires updates to `ReefGuide` and `ReefGuideWorker`