### PR TITLE
feat: config for sentry DSN for webAPI and app

### DIFF
--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -8,6 +8,8 @@ declare interface Env {
   NG_APP_SPLASH_SHOW_BACKGROUND_MAP: string;
   NG_APP_DOCUMENTATION_LINK: string;
   NG_APP_ABOUT_LINK: string;
+  // Optional Sentry DSN for error tracking
+  NG_APP_SENTRY_DSN?: string;
 }
 
 declare interface ImportMeta {

--- a/packages/app/src/environments/types.ts
+++ b/packages/app/src/environments/types.ts
@@ -21,7 +21,8 @@ export const envSchema = z.object({
     .transform(val => val === 'true')
     .default('true'),
   DOCUMENTATION_LINK: z.string().url().default('https://github.com/open-AIMS/reefguide'),
-  ABOUT_LINK: z.string().url().default('https://github.com/open-AIMS/reefguide')
+  ABOUT_LINK: z.string().url().default('https://github.com/open-AIMS/reefguide'),
+  SENTRY_DSN: z.string().url().optional().describe('Sentry DSN for error tracking')
 });
 
 // Interface for the structured environment configuration
@@ -30,6 +31,7 @@ export interface EnvironmentConfig {
   adriaApiUrl: string;
   webApiUrl: string;
   splashConfig: SplashConfig;
+  sentryDsn?: string;
 }
 
 // Type for raw environment variables
@@ -44,7 +46,8 @@ export function buildConfig(): EnvironmentConfig {
     SPLASH_APP_NAME: import.meta.env.NG_APP_SPLASH_APP_NAME,
     SPLASH_SHOW_BACKGROUND_MAP: import.meta.env.NG_APP_SPLASH_SHOW_BACKGROUND_MAP,
     DOCUMENTATION_LINK: import.meta.env.NG_APP_DOCUMENTATION_LINK,
-    ABOUT_LINK: import.meta.env.NG_APP_ABOUT_LINK
+    ABOUT_LINK: import.meta.env.NG_APP_ABOUT_LINK,
+    SENTRY_DSN: import.meta.env.NG_APP_SENTRY_DSN
   };
 
   // Validate environment variables using Zod (with defaults applied)
@@ -64,6 +67,7 @@ export function buildConfig(): EnvironmentConfig {
         'Your account needs analyst or administrator access to use this application.',
       aboutLink: validatedEnv.ABOUT_LINK,
       documentationLink: validatedEnv.DOCUMENTATION_LINK
-    }
+    },
+    sentryDsn: validatedEnv.SENTRY_DSN
   };
 }

--- a/packages/app/turbo.json
+++ b/packages/app/turbo.json
@@ -13,7 +13,8 @@
         "NG_APP_SPLASH_APP_NAME",
         "NG_APP_SPLASH_SHOW_BACKGROUND_MAP",
         "NG_APP_DOCUMENTATION_LINK",
-        "NG_APP_ABOUT_LINK"
+        "NG_APP_ABOUT_LINK",
+        "NG_APP_SENTRY_DSN"
       ]
     }
   }

--- a/packages/infra/configs/sample.json
+++ b/packages/infra/configs/sample.json
@@ -79,5 +79,9 @@
                 }
             }
         }
+    },
+    "monitoring": {
+        "webApiSentryDsn": "https://example.com",
+        "appSentryDsn": "https://example.com"
     }
 }

--- a/packages/infra/src/components/ecsWebAPI.ts
+++ b/packages/infra/src/components/ecsWebAPI.ts
@@ -38,6 +38,8 @@ export interface ECSWebAPIProps {
   adminCreds: sm.Secret;
   /** The name of jobs system s3 bucket to store in */
   storageBucket: s3.IBucket;
+  /** The Sentry DSN for the web API */
+  sentryDsn?: string;
 }
 
 /**
@@ -129,7 +131,10 @@ export class ECSWebAPI extends Construct {
         AWS_REGION: cdk.Stack.of(this).region,
 
         // Storage bucket name
-        S3_BUCKET_NAME: props.storageBucket.bucketName
+        S3_BUCKET_NAME: props.storageBucket.bucketName,
+
+        // Sentry DSN
+        ...(props.sentryDsn ? { SENTRY_DSN: props.sentryDsn } : {})
       },
       secrets: {
         // API Secret

--- a/packages/infra/src/components/reefGuideFrontend.ts
+++ b/packages/infra/src/components/reefGuideFrontend.ts
@@ -34,6 +34,8 @@ export interface ReefGuideFrontendProps {
   adminEmail: string;
   /** App name to display in login panel */
   appName: string;
+  /** The Sentry DSN for the app */
+  sentryDsn?: string;
 }
 
 /**
@@ -114,7 +116,9 @@ export class ReefGuideFrontend extends Construct {
       NG_APP_SPLASH_APP_NAME: props.appName,
       NG_APP_SPLASH_SHOW_BACKGROUND_MAP: 'true',
       NG_APP_DOCUMENTATION_LINK: 'https://open-aims.github.io/reefguide',
-      NG_APP_ABOUT_LINK: 'https://github.com/open-AIMS/reefguide'
+      NG_APP_ABOUT_LINK: 'https://github.com/open-AIMS/reefguide',
+      // Sentry DSN
+      ...(props.sentryDsn ? { NG_APP_SENTRY_DSN: props.sentryDsn } : {})
     };
 
     // Setup deployment with build process

--- a/packages/infra/src/infra.ts
+++ b/packages/infra/src/infra.ts
@@ -167,7 +167,8 @@ export class ReefguideStack extends cdk.Stack {
         adminCreds: adminCreds,
         cluster: cluster,
         sharedBalancer: networking.sharedBalancer,
-        vpc: networking.vpc
+        vpc: networking.vpc,
+        sentryDsn: config.monitoring?.webApiSentryDsn
       });
     } else {
       // Lambda mode
@@ -196,7 +197,8 @@ export class ReefguideStack extends cdk.Stack {
       ].concat(ARC_GIS_ENDPOINTS),
       webApiEndpoint: webAPI.endpoint,
       adminEmail: config.frontend.adminEmail,
-      appName: config.frontend.appName
+      appName: config.frontend.appName,
+      sentryDsn: config.monitoring?.appSentryDsn
     });
 
     const { jobSystem } = config;

--- a/packages/infra/src/infraConfig.ts
+++ b/packages/infra/src/infraConfig.ts
@@ -3,6 +3,14 @@ import * as path from 'path';
 import * as z from 'zod';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
+export const MonitoringSchema = z.object({
+  /** The ARN of the Sentry DSN for the web API */
+  webApiSentryDsn: z.string().url().optional(),
+  /** The ARN of the Sentry DSN for the app */
+  appSentryDsn: z.string().url().optional()
+});
+export type MonitoringConfig = z.infer<typeof MonitoringSchema>;
+
 export const ReefGuideFrontendConfigSchema = z.object({
   /** The index document of the website */
   indexDocument: z.string().default('index.html'),
@@ -196,7 +204,10 @@ export const DeploymentConfigSchema = z.object({
   db: DatabaseConfigSchema.optional(),
 
   // Job system configuration
-  jobSystem: JobSystemConfigSchema.default({})
+  jobSystem: JobSystemConfigSchema.default({}),
+
+  // Monitoring configuration
+  monitoring: MonitoringSchema.optional()
 });
 export type DeploymentConfig = z.infer<typeof DeploymentConfigSchema>;
 

--- a/packages/web-api/src/config.ts
+++ b/packages/web-api/src/config.ts
@@ -47,7 +47,8 @@ const envSchema = z.object({
     .transform(val => parseInt(val, 10))
     .refine(val => !isNaN(val) && val > 0, {
       message: 'REFRESH_TOKEN_EXPIRY_MINUTES must be a positive number'
-    })
+    }),
+  SENTRY_DSN: z.string().url().optional().describe('Sentry DSN for error tracking')
 });
 
 /**
@@ -89,6 +90,8 @@ export interface Config {
     accessTokenExpirySeconds: number; // Computed convenience property
   };
   disableCache: boolean;
+  // Optional Sentry DSN for error tracking
+  sentryDsn?: string;
 }
 
 /**
@@ -155,7 +158,8 @@ export function getConfig(): Config {
       // Computed convenience property for seconds
       accessTokenExpirySeconds: env.ACCESS_TOKEN_EXPIRY_MINUTES * 60
     },
-    disableCache: env.DISABLE_CACHE
+    disableCache: env.DISABLE_CACHE,
+    sentryDsn: env.SENTRY_DSN
   };
 
   // Log configuration in non-production environments (excluding sensitive data)


### PR DESCRIPTION
Adds environment variable configuration to let the web API and app know a sentry DSN to report errors to. 

Has not been instrumented yet, and we should include the capacity manager and job services too.