### PR TITLE
Capture console.error, don't log JWT token

### DIFF
--- a/packages/app/src/app/app.config.ts
+++ b/packages/app/src/app/app.config.ts
@@ -15,7 +15,7 @@ if (enableSentry) {
   Sentry.init({
     dsn: environment.sentryDsn,
     sendDefaultPii: false,
-    integrations: [],
+    integrations: [Sentry.captureConsoleIntegration({ levels: ['error'] })],
     // was specified in bugsink documentation.
     tracesSampleRate: 0
   });

--- a/packages/app/src/app/auth/auth.service.ts
+++ b/packages/app/src/app/auth/auth.service.ts
@@ -270,7 +270,8 @@ export class AuthService {
       return false;
     }
 
-    console.log('onAuth', auth);
+    // IMPORTANT: do NOT log full auth object to avoid token capture by Sentry
+    console.log('onAuth', auth.user);
     this.auth = auth;
 
     // Update both signals when user data changes


### PR DESCRIPTION
* turn on capture console.error
* avoid logging object with JWT token
