### PR TITLE
Fix project dialog double scrollbars and height issues

### DIFF
--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
@@ -1,12 +1,13 @@
 <form [formGroup]="createForm" (ngSubmit)="onSubmit()">
-  <div mat-dialog-title>
-    <h2>Create New Project</h2>
-    <p class="dialog-subtitle">
-      Choose a project type and provide basic information to get started.
-    </p>
-  </div>
-
   <div mat-dialog-content class="dialog-content">
+
+    <div mat-dialog-title>
+      <h2>Create New Project</h2>
+      <p class="dialog-subtitle">
+        Choose a project type and provide basic information to get started.
+      </p>
+    </div>
+
     <!-- Project Type Selection -->
     <div class="form-section">
       <h3>Project Type</h3>

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.html
@@ -1,6 +1,5 @@
 <form [formGroup]="createForm" (ngSubmit)="onSubmit()">
   <div mat-dialog-content class="dialog-content">
-
     <div mat-dialog-title>
       <h2>Create New Project</h2>
       <p class="dialog-subtitle">

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
@@ -201,9 +201,9 @@ form {
 [mat-dialog-title] {
   // title is within dialog content, so remove padding
   padding: 0 0 16px 0;
-   h2 {
-     margin: 0;
-   }
+  h2 {
+    margin: 0;
+  }
 }
 
 // Ensure dialog container can grow

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
@@ -5,21 +5,8 @@
   font-weight: 400;
 }
 
-.dialog-content {
-  padding: 24px !important;
-  margin: 0;
-  max-width: none;
-  min-height: 450px;
-  max-height: 80vh;
-  overflow-y: auto;
-}
-
 .form-section {
-  margin-bottom: 32px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  padding-bottom: 32px;
 
   h3 {
     margin: 0 0 20px 0;
@@ -103,8 +90,7 @@
 }
 
 .project-type-content {
-  padding: 24px;
-  padding-right: 72px; // Increased space for radio button + margin
+  padding: 16px;
   width: 100%;
   background-color: white;
   border-radius: 10px;
@@ -207,10 +193,12 @@
   }
 }
 
-// Dialog title styling to ensure proper padding
-::ng-deep .mat-mdc-dialog-title {
-  padding: 16px 24px 0 24px !important;
-  margin: 0 !important;
+[mat-dialog-title] {
+  // title is within dialog content, so remove padding
+  padding: 0 0 16px 0;
+   h2 {
+     margin: 0;
+   }
 }
 
 // Ensure dialog container can grow

--- a/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
+++ b/packages/app/src/app/projects/create-project-dialog/create-project-dialog.component.scss
@@ -1,3 +1,16 @@
+// <form> wraps dialog content and actions
+form {
+  // form is not a layout element, prevent double scrollbars
+  display: contents;
+}
+
+.dialog-content {
+  // default max-height of 65vh limits our ability to increase dialog height
+  // none seems to work fine, but assuming 65vh was set for a reason, so set it to
+  // full height minus action bar height
+  max-height: calc(100vh - 74px);
+}
+
 .dialog-subtitle {
   margin: 8px 0 0 0;
   color: rgba(0, 0, 0, 0.6);
@@ -169,19 +182,11 @@
 }
 
 .dialog-actions {
-  padding: 24px !important;
-  margin: 0;
-  justify-content: flex-end;
   gap: 12px;
   border-top: 1px solid #e0e0e0;
 
   button {
     min-width: 80px;
-    height: 40px;
-
-    &[mat-raised-button] {
-      min-width: 140px;
-    }
   }
 }
 
@@ -202,9 +207,8 @@
 }
 
 // Ensure dialog container can grow
-::ng-deep .mat-mdc-dialog-container {
-  max-height: 80vh !important;
-  height: auto !important;
+::ng-deep .mat-mdc-dialog-panel {
+  max-height: 85vh;
 }
 
 // Success and error snackbar styles
@@ -220,23 +224,13 @@
 
 // Responsive adjustments
 @media (max-width: 600px) {
+  ::ng-deep .mat-mdc-dialog-panel {
+    // set height on overall dialog
+    max-height: 95vh; // Slightly more space on mobile
+  }
+
   .dialog-content {
     padding: 16px !important;
-    min-height: 400px;
-    max-height: 85vh; // Slightly more space on mobile
-  }
-
-  ::ng-deep .mat-mdc-dialog-title {
-    padding: 12px 16px 0 16px !important;
-  }
-
-  .dialog-actions {
-    padding: 16px !important;
-  }
-
-  .project-type-content {
-    padding: 20px;
-    padding-right: 64px; // Adjusted for mobile radio button space
   }
 
   .project-type-header {


### PR DESCRIPTION
* Fix double-scrollbars in project dialog
* move title to content so that it scrolls
* simplify css a bit 

<img width="841" height="851" alt="image" src="https://github.com/user-attachments/assets/7755375b-cc7c-4694-bc4c-70976d1d47fe" />

