### PR TITLE
feat: basic auth guards

### DIFF
--- a/packages/app/src/app/app.routes.ts
+++ b/packages/app/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 // src/app/app.routes.ts
 import { Routes } from '@angular/router';
 import { JobsTableComponent } from './jobs/jobs-table/jobs-table.component';
+import { authGuard } from './auth.guard';
+import { projectAuthGuard } from './project-auth.guard';
 
 export const routes: Routes = [
   {
@@ -13,7 +15,8 @@ export const routes: Routes = [
     path: 'adria/:projectId',
     loadComponent: () =>
       import('./model-workflow/model-workflow.component').then(m => m.ModelWorkflowComponent),
-    title: 'ADRIA Model Run'
+    title: 'ADRIA Model Run',
+    canActivate: [authGuard, projectAuthGuard]
   },
   {
     path: 'location-selection/:projectId',
@@ -22,11 +25,13 @@ export const routes: Routes = [
         console.log('selection');
         return m.LocationSelectionComponent;
       }),
-    title: 'Location Selection'
+    title: 'Location Selection',
+    canActivate: [authGuard, projectAuthGuard]
   },
   {
     path: 'jobs',
     component: JobsTableComponent,
-    title: 'My Jobs'
+    title: 'My Jobs',
+    canActivate: [authGuard]
   }
 ];

--- a/packages/app/src/app/auth.guard.spec.ts
+++ b/packages/app/src/app/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/auth.guard.spec.ts
+++ b/packages/app/src/app/auth.guard.spec.ts
@@ -4,8 +4,8 @@ import { CanActivateFn } from '@angular/router';
 import { authGuard } from './auth.guard';
 
 describe('authGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => authGuard(...guardParameters));
 
   beforeEach(() => {
     TestBed.configureTestingModule({});

--- a/packages/app/src/app/auth.guard.ts
+++ b/packages/app/src/app/auth.guard.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, RedirectCommand, Router } from '@angular/router';
+import { AuthService } from './auth/auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+/**
+ * NG auth guard - checks if user is authenticated else redirects -> home page
+ */
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const snackBar = inject(MatSnackBar);
+  const router = inject(Router);
+
+  if (!authService.authenticated()) {
+    const msg = `Not authenticated!`;
+    snackBar.open(msg);
+    return new RedirectCommand(router.parseUrl('/'), {});
+  }
+
+  return true;
+};

--- a/packages/app/src/app/project-auth.guard.spec.ts
+++ b/packages/app/src/app/project-auth.guard.spec.ts
@@ -4,8 +4,8 @@ import { CanActivateFn } from '@angular/router';
 import { projectAuthGuard } from './project-auth.guard';
 
 describe('projectAuthGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => projectAuthGuard(...guardParameters));
+  const executeGuard: CanActivateFn = (...guardParameters) =>
+    TestBed.runInInjectionContext(() => projectAuthGuard(...guardParameters));
 
   beforeEach(() => {
     TestBed.configureTestingModule({});

--- a/packages/app/src/app/project-auth.guard.spec.ts
+++ b/packages/app/src/app/project-auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { projectAuthGuard } from './project-auth.guard';
+
+describe('projectAuthGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => projectAuthGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/project-auth.guard.ts
+++ b/packages/app/src/app/project-auth.guard.ts
@@ -1,0 +1,35 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, RedirectCommand, Router } from '@angular/router';
+import { AuthService } from './auth/auth.service';
+import { WebApiService } from '../api/web-api.service';
+import { firstValueFrom } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+/**
+ * NG auth guard - checks if user is authenticated and can load the project else
+ * redirects
+ */
+export const projectAuthGuard: CanActivateFn = async (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const webApiService = inject(WebApiService);
+  const projectId: string | undefined = route.params['projectId'];
+  const snackBar = inject(MatSnackBar);
+
+  if (authService.authenticated() && !!projectId) {
+    try {
+      // try and load project
+      const canResolve = await firstValueFrom(webApiService.getProject(Number(projectId)));
+      if (canResolve) {
+        return true;
+      }
+    } catch (e) {
+      const msg = `Trying to load route for project with ID ${projectId} which experienced error. Do you own this project?`;
+      snackBar.open(msg);
+      console.warn(msg + e);
+    }
+  }
+
+  // return to base
+  return new RedirectCommand(router.parseUrl('/'), {});
+};


### PR DESCRIPTION
Adds two CanActivate auth guards. One for general sign in. One checks projectId param - if load fails then it throws back to main screen. Both emit snackbars on error.