### PR TITLE
feat: reef-search

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@reefguide/types": "workspace:*",
     "@sentry/angular": "^10.4.0",
     "apache-arrow": "^21.0.0",
+    "fuzzysort": "^3.1.0",
     "jwt-decode": "^4.0.0",
     "ol": "^10.6.1",
     "parquet-wasm": "^0.6.1",
@@ -39,10 +40,10 @@
     "zod": "^3.25.62"
   },
   "devDependencies": {
-    "@sentry/cli": "^2.53.0",
     "@angular-devkit/build-angular": "^20.2.0",
     "@angular/cli": "^20.2.0",
     "@angular/compiler-cli": "^20.2.1",
+    "@sentry/cli": "^2.53.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",

--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -604,4 +604,26 @@ export class ReefGuideMapService {
 
     return this.createLayerController(layer, options);
   }
+
+  /**
+   * Show/hide an info layer by its ID
+   * @param layerId the layer ID to show/hide
+   * @param visible whether to make the layer visible
+   */
+  showInfoLayer(layerId: string, visible: boolean = true) {
+    // Get all layers from the map
+    const allLayers = this.map.getAllLayers();
+
+    // Find the layer with the matching ID
+    const targetLayer = allLayers.find(layer => {
+      const properties = layer.getProperties();
+      return properties['id'] === layerId;
+    });
+
+    if (targetLayer) {
+      targetLayer.setVisible(visible);
+    } else {
+      console.warn(`Info layer with ID "${layerId}" not found`);
+    }
+  }
 }

--- a/packages/app/src/app/reef-map/reef-map.component.html
+++ b/packages/app/src/app/reef-map/reef-map.component.html
@@ -1,11 +1,14 @@
 <div #olMap class="map"></div>
 <div class="left-toolbar" [style.visibility]="hideLeftToolbar() ? 'hidden' : 'visible'">
   <!--- Return to the projects page-->
-  <div class="back-button">
-    <button mat-icon-button class="back-button" matTooltip="Back to projects" (click)="goBack()">
-      <mat-icon>arrow_back</mat-icon>
-    </button>
-    <span class="back-button-text">Return to projects</span>
+  <div class="panel-row">
+    <div class="back-button">
+      <button mat-icon-button class="back-button" matTooltip="Back to projects" (click)="goBack()">
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+      <span class="back-button-text">Return to projects</span>
+    </div>
+    <app-reef-search></app-reef-search>
   </div>
   <app-layer-list></app-layer-list>
   <!-- content from parent. if needed can use selectors to position first/last etc. -->

--- a/packages/app/src/app/reef-map/reef-map.component.html
+++ b/packages/app/src/app/reef-map/reef-map.component.html
@@ -8,7 +8,9 @@
       </button>
       <span class="back-button-text">Return to projects</span>
     </div>
-    <app-reef-search></app-reef-search>
+    <div class="search-box">
+      <app-reef-search (reefSelected)="onFlyToCanonicalReef({ id: $event.id })"></app-reef-search>
+    </div>
   </div>
   <app-layer-list></app-layer-list>
   <!-- content from parent. if needed can use selectors to position first/last etc. -->

--- a/packages/app/src/app/reef-map/reef-map.component.scss
+++ b/packages/app/src/app/reef-map/reef-map.component.scss
@@ -19,18 +19,25 @@
   left: 12px;
   align-items: flex-start;
 
-  .back-button {
+  .panel-row {
     display: flex;
     flex-direction: row;
     gap: 8px;
     align-items: center;
-    background-color: rgba(240, 248, 255, 0.75);
-    border-radius: 20px;
 
-    .back-button-text {
-      font-size: medium;
-      margin-right: 12px;
-      font-weight: 550;
+    .back-button {
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+      align-items: center;
+      background-color: rgba(240, 248, 255, 0.75);
+      border-radius: 20px;
+
+      .back-button-text {
+        font-size: medium;
+        margin-right: 12px;
+        font-weight: 550;
+      }
     }
   }
 }

--- a/packages/app/src/app/reef-map/reef-map.component.scss
+++ b/packages/app/src/app/reef-map/reef-map.component.scss
@@ -39,5 +39,13 @@
         font-weight: 550;
       }
     }
+
+    .search-box {
+      padding: 16px;
+      margin-bottom: 0;
+      display: block;
+      background-color: rgba(240, 248, 255, 0.9);
+      border-radius: 20px;
+    }
   }
 }

--- a/packages/app/src/app/reef-map/reef-map.component.ts
+++ b/packages/app/src/app/reef-map/reef-map.component.ts
@@ -27,6 +27,7 @@ import { FeatureRef } from '../map/openlayers-types';
 import { Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { ReefSearchComponent } from "./reef-search/reef-search.component";
 
 /**
  * OpenLayers map and UI for layer management and map navigation.
@@ -38,7 +39,7 @@ import { MatButtonModule } from '@angular/material/button';
 @Component({
   selector: 'app-reef-map',
   templateUrl: './reef-map.component.html',
-  imports: [LayerListComponent, JobStatusListComponent, MatIconModule, MatButtonModule],
+  imports: [LayerListComponent, JobStatusListComponent, MatIconModule, MatButtonModule, ReefSearchComponent],
   styleUrl: './reef-map.component.scss'
 })
 export class ReefMapComponent implements AfterViewInit {

--- a/packages/app/src/app/reef-map/reef-search.service.spec.ts
+++ b/packages/app/src/app/reef-map/reef-search.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ReefSearchService } from './reef-search.service';
+
+describe('ReefSearchService', () => {
+  let service: ReefSearchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ReefSearchService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/reef-map/reef-search.service.ts
+++ b/packages/app/src/app/reef-map/reef-search.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, signal } from '@angular/core';
+import fuzzysort from 'fuzzysort';
+
+// This gets the name, unique ID of all reefs in the canonical reefs
+// dataset
+const CANONICAL_REEFS_NAME_QUERY =
+  'https://services3.arcgis.com/wfyOCawpdks4prqC/arcgis/rest/services/RRAP_Canonical_Reefs/FeatureServer/0/query?where=1%3D1&outFields=reef_name,UNIQUE_ID&returnGeometry=false&f=json';
+
+export interface ReefNameQueryResponseFormat {
+  features: {
+    attributes: {
+      reef_name: string;
+      UNIQUE_ID: string;
+    };
+  }[];
+}
+
+export interface ReefData {
+  reefs: {
+    name: string;
+    id: string;
+  }[];
+}
+
+export interface ReefSearchResult {
+  results: {
+    id: string;
+    name: string;
+  }[];
+}
+
+export interface ReefSearchQuery {
+  query: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReefSearchService {
+  // Private state
+  private reefData: ReefData | undefined = undefined;
+
+  // Busy searching?
+  searching = signal<boolean>(false);
+  // Results - if any
+  results = signal<ReefSearchResult | undefined>(undefined);
+  // Error information - if something went wrong
+  error = signal<string | undefined>(undefined);
+  // Are we ready to accept searches?
+  readyForSearch = signal<boolean>(false);
+
+  constructor() {
+    this.fetchReefNames();
+  }
+
+  /**
+   * Initialisation logic upon construction of this service - fetches the reef
+   * data.
+   */
+  private async fetchReefNames() {
+    const response = await fetch(CANONICAL_REEFS_NAME_QUERY, { method: 'GET' });
+    if (!response.ok) {
+      let errorText: string | undefined;
+      try {
+        errorText = await response.text();
+      } catch {
+        errorText = 'Unknown error';
+      }
+
+      console.error(
+        `Failed to retrieve reef details. Error ${errorText}. Status: ${response.statusText}`
+      );
+      this.error.set('Reef information could not be retrieved! Contact a system administrator.');
+    }
+
+    try {
+      // get JSON from payload
+      const jsonData: ReefNameQueryResponseFormat = await response.json();
+
+      // parse
+      const parsedData: ReefData = {
+        reefs: jsonData.features.map(f => ({
+          id: f.attributes.UNIQUE_ID,
+          name: f.attributes.reef_name
+        }))
+      };
+
+      this.reefData = parsedData;
+      this.readyForSearch.set(true);
+    } catch (e) {
+      console.error(
+        `Failed to retrieve reef details. Error ${response.text}. Status: ${response.statusText}`
+      );
+      this.error.set('Reef information could not be retrieved! Contact a system administrator.');
+    }
+  }
+
+  /**
+   * Searches for reefs using the Canonical reefs as the dataset
+   *
+   * @returns Top 10 results ordered by match - fuzzy searching
+   */
+  search({ query }: ReefSearchQuery) {
+    this.searching.set(true);
+
+    // Fuzzy searching
+    const rawSearchResults = fuzzysort.go(query, this.reefData?.reefs ?? [], {
+      key: 'name',
+      limit: 10
+    });
+
+    // Parse it out
+    const parsedResults = { results: rawSearchResults.map(r => r.obj) };
+
+    // Update data
+    this.results.set(parsedResults);
+
+    // Loading finished
+    this.searching.set(false);
+  }
+}

--- a/packages/app/src/app/reef-map/reef-search.service.ts
+++ b/packages/app/src/app/reef-map/reef-search.service.ts
@@ -1,10 +1,13 @@
 import { Injectable, signal } from '@angular/core';
 import fuzzysort from 'fuzzysort';
 
-// This gets the name, unique ID of all reefs in the canonical reefs
-// dataset
-const CANONICAL_REEFS_NAME_QUERY =
-  'https://services3.arcgis.com/wfyOCawpdks4prqC/arcgis/rest/services/RRAP_Canonical_Reefs/FeatureServer/0/query?where=1%3D1&outFields=reef_name,UNIQUE_ID&returnGeometry=false&f=json';
+const CANONICAL_REEFS_BASE =
+  'https://services3.arcgis.com/wfyOCawpdks4prqC/arcgis/rest/services/RRAP_Canonical_Reefs/FeatureServer/0';
+// This gets the name, unique ID of all reefs in the canonical reefs dataset
+const CANONICAL_REEFS_NAME_QUERY = `${CANONICAL_REEFS_BASE}/query?where=1%3D1&outFields=reef_name,UNIQUE_ID&returnGeometry=false&f=json`;
+// Get geometry by ID
+const CANONICAL_REEFS_GEOMETRY_QUERY = (id: string) =>
+  `${CANONICAL_REEFS_BASE}/query?where=UNIQUE_ID%3D'${encodeURIComponent(id)}'&outFields=reef_name,UNIQUE_ID&returnGeometry=true&f=json`;
 
 export interface ReefNameQueryResponseFormat {
   features: {
@@ -12,6 +15,12 @@ export interface ReefNameQueryResponseFormat {
       reef_name: string;
       UNIQUE_ID: string;
     };
+  }[];
+}
+
+export interface ReefGeometryQueryResponseFormat {
+  features: {
+    geometry: any;
   }[];
 }
 
@@ -31,6 +40,10 @@ export interface ReefSearchResult {
 
 export interface ReefSearchQuery {
   query: string;
+}
+
+export interface ReefGeometryQuery {
+  id: string;
 }
 
 @Injectable({
@@ -58,22 +71,23 @@ export class ReefSearchService {
    * data.
    */
   private async fetchReefNames() {
-    const response = await fetch(CANONICAL_REEFS_NAME_QUERY, { method: 'GET' });
-    if (!response.ok) {
-      let errorText: string | undefined;
-      try {
-        errorText = await response.text();
-      } catch {
-        errorText = 'Unknown error';
+    try {
+      const response = await fetch(CANONICAL_REEFS_NAME_QUERY, { method: 'GET' });
+      if (!response.ok) {
+        console.log('Error occurred while trying to fetch from canonical reefs feature service.');
+        let errorText: string | undefined;
+        try {
+          errorText = await response.text();
+        } catch {
+          errorText = 'Unknown error';
+        }
+
+        console.error(
+          `Failed to retrieve reef details. Error ${errorText}. Status: ${response.statusText}`
+        );
+        this.error.set('Reef information could not be retrieved! Contact a system administrator.');
       }
 
-      console.error(
-        `Failed to retrieve reef details. Error ${errorText}. Status: ${response.statusText}`
-      );
-      this.error.set('Reef information could not be retrieved! Contact a system administrator.');
-    }
-
-    try {
       // get JSON from payload
       const jsonData: ReefNameQueryResponseFormat = await response.json();
 
@@ -88,9 +102,7 @@ export class ReefSearchService {
       this.reefData = parsedData;
       this.readyForSearch.set(true);
     } catch (e) {
-      console.error(
-        `Failed to retrieve reef details. Error ${response.text}. Status: ${response.statusText}`
-      );
+      console.error(`Failed to retrieve reef details. Error ${e}.`);
       this.error.set('Reef information could not be retrieved! Contact a system administrator.');
     }
   }
@@ -117,5 +129,49 @@ export class ReefSearchService {
 
     // Loading finished
     this.searching.set(false);
+  }
+
+  /**
+   * Gets a specific reef by ID including geometry
+   *
+   * @returns Promise that resolves to the geometry of the reef or throws a string error
+   */
+  async getGeometry({ id }: ReefGeometryQuery): Promise<any> {
+    try {
+      const response = await fetch(CANONICAL_REEFS_GEOMETRY_QUERY(id), { method: 'GET' });
+
+      if (!response.ok) {
+        let errorText: string | undefined;
+        try {
+          errorText = await response.text();
+        } catch {
+          errorText = 'Unknown error';
+        }
+        throw `Failed to retrieve reef geometry (ID=${id}). Error ${errorText}. Status: ${response.statusText}`;
+      }
+
+      // get JSON from payload
+      const jsonData: ReefGeometryQueryResponseFormat = await response.json();
+
+      // Check if we got any features back
+      if (!jsonData.features || jsonData.features.length === 0) {
+        throw `No reef found with ID: ${id}`;
+      }
+
+      // Return the geometry of the first (and should be only) feature
+      const feature = jsonData.features[0];
+      if (!feature.geometry) {
+        throw `Reef found (ID=${id}) but no geometry data available`;
+      }
+
+      return feature.geometry;
+    } catch (e) {
+      // If it's already a string error we threw, re-throw it
+      if (typeof e === 'string') {
+        throw e;
+      }
+      // Otherwise, wrap the error
+      throw `Failed to retrieve reef geometry (ID=${id}). Error: ${e}`;
+    }
   }
 }

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.html
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.html
@@ -1,0 +1,42 @@
+<div class="reef-search-container">
+  <mat-form-field appearance="outline" class="search-field">
+    <mat-label>Search for reefs</mat-label>
+    <input
+      matInput
+      [matAutocomplete]="auto"
+      (input)="search($event.target.value)"
+      placeholder="Type to search reefs..."
+    />
+    <mat-icon matPrefix class="search-icon">search</mat-icon>
+  </mat-form-field>
+
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    [displayWith]="displayReef"
+    (optionSelected)="onReefSelected($event)"
+    class="reef-autocomplete">
+    @for (option of reefSearchService.results()?.results ?? []; track option.id) {
+      <mat-option [value]="option" class="reef-option">
+        <span class="reef-name">{{ option.name }}</span>
+      </mat-option>
+    }
+
+    @if (reefSearchService.searching()) {
+      <mat-option disabled>
+        <span class="loading-text">Searching...</span>
+      </mat-option>
+    }
+
+    @if (reefSearchService.error()) {
+      <mat-option disabled>
+        <span class="error-text">{{ reefSearchService.error() }}</span>
+      </mat-option>
+    }
+
+    @if (!reefSearchService.searching() && !reefSearchService.error() && reefSearchService.results() && (reefSearchService.results()?.results?.length ?? 0) === 0) {
+      <mat-option disabled>
+        <span class="no-results-text">No reefs found</span>
+      </mat-option>
+    }
+  </mat-autocomplete>
+</div>

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.html
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.html
@@ -1,42 +1,45 @@
-<div class="reef-search-container">
-  <mat-form-field appearance="outline" class="search-field">
-    <mat-label>Search for reefs</mat-label>
-    <input
-      matInput
-      [matAutocomplete]="auto"
-      (input)="search($event.target.value)"
-      placeholder="Type to search reefs..."
-    />
-    <mat-icon matPrefix class="search-icon">search</mat-icon>
-  </mat-form-field>
+<mat-form-field appearance="outline" class="search-field" subscriptSizing="dynamic">
+  <mat-label>Search for reefs</mat-label>
+  <input
+    matInput
+    [matAutocomplete]="auto"
+    [formControl]="searchControl"
+    placeholder="Type to search reefs..."
+  />
+  <mat-icon matPrefix class="search-icon">search</mat-icon>
+</mat-form-field>
 
-  <mat-autocomplete
-    #auto="matAutocomplete"
-    [displayWith]="displayReef"
-    (optionSelected)="onReefSelected($event)"
-    class="reef-autocomplete">
-    @for (option of reefSearchService.results()?.results ?? []; track option.id) {
-      <mat-option [value]="option" class="reef-option">
-        <span class="reef-name">{{ option.name }}</span>
-      </mat-option>
-    }
+<mat-autocomplete
+  #auto="matAutocomplete"
+  [displayWith]="displayReef"
+  (optionSelected)="onReefSelected($event)"
+>
+  @for (option of reefSearchService.results()?.results ?? []; track option.id) {
+    <mat-option [value]="option" class="reef-option">
+      <span class="reef-name">{{ option.name }}</span>
+    </mat-option>
+  }
 
-    @if (reefSearchService.searching()) {
-      <mat-option disabled>
-        <span class="loading-text">Searching...</span>
-      </mat-option>
-    }
+  @if (reefSearchService.searching()) {
+    <mat-option disabled>
+      <span class="loading-text">Searching...</span>
+    </mat-option>
+  }
 
-    @if (reefSearchService.error()) {
-      <mat-option disabled>
-        <span class="error-text">{{ reefSearchService.error() }}</span>
-      </mat-option>
-    }
+  @if (reefSearchService.error()) {
+    <mat-option disabled>
+      <span class="error-text">{{ reefSearchService.error() }}</span>
+    </mat-option>
+  }
 
-    @if (!reefSearchService.searching() && !reefSearchService.error() && reefSearchService.results() && (reefSearchService.results()?.results?.length ?? 0) === 0) {
-      <mat-option disabled>
-        <span class="no-results-text">No reefs found</span>
-      </mat-option>
-    }
-  </mat-autocomplete>
-</div>
+  @if (
+    !reefSearchService.searching() &&
+    !reefSearchService.error() &&
+    reefSearchService.results() &&
+    (reefSearchService.results()?.results?.length ?? 0) === 0
+  ) {
+    <mat-option disabled>
+      <span class="no-results-text">No reefs found</span>
+    </mat-option>
+  }
+</mat-autocomplete>

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
@@ -2,7 +2,7 @@
   width: 100%;
   .search-icon {
     color: rgba(0, 0, 0, 0.54);
-    margin-right: 8px;
+    margin-right: 2px;
   }
 }
 

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
@@ -1,0 +1,34 @@
+.reef-search-container {
+  width: 100%;
+}
+
+.search-field {
+  width: 100%;
+  .search-icon {
+    color: rgba(0, 0, 0, 0.54);
+    margin-right: 8px;
+  }
+}
+
+.loading-text {
+  color: rgba(0, 0, 0, 0.54);
+  font-style: italic;
+  font-size: 14px;
+}
+
+.error-text {
+  color: #f44336;
+  font-size: 14px;
+}
+
+.no-results-text {
+  color: rgba(0, 0, 0, 0.54);
+  font-size: 14px;
+  font-style: italic;
+}
+
+::ng-deep .mat-form-field {
+  .mat-input-element {
+    background-color: rgb(112, 144, 114);
+  }
+}

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.scss
@@ -1,7 +1,3 @@
-.reef-search-container {
-  width: 100%;
-}
-
 .search-field {
   width: 100%;
   .search-icon {

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.spec.ts
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.spec.ts
@@ -9,8 +9,7 @@ describe('ReefSearchComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ReefSearchComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ReefSearchComponent);
     component = fixture.componentInstance;

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.spec.ts
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReefSearchComponent } from './reef-search.component';
+
+describe('ReefSearchComponent', () => {
+  let component: ReefSearchComponent;
+  let fixture: ComponentFixture<ReefSearchComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReefSearchComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ReefSearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.ts
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.ts
@@ -1,24 +1,49 @@
 import { Component, inject, output } from '@angular/core';
-import { ReefSearchService } from '../reef-search.service';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { debounceTime, distinctUntilChanged, Subject, takeUntil } from 'rxjs';
+import { ReefSearchService } from '../reef-search.service';
 
 @Component({
   selector: 'app-reef-search',
-  imports: [MatAutocompleteModule, MatFormFieldModule, MatInputModule, MatIconModule],
+  imports: [
+    MatAutocompleteModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    ReactiveFormsModule
+  ],
   templateUrl: './reef-search.component.html',
   styleUrl: './reef-search.component.scss'
 })
 export class ReefSearchComponent {
   public reefSearchService = inject(ReefSearchService);
+  searchControl = new FormControl<string>('');
+  private destroy$ = new Subject<void>();
+  private isSelecting = false; // Add this flag
 
   // Output event for when a reef is selected
   reefSelected = output<{ id: string; name: string }>();
 
-  search(query: string) {
-    const trimmedQuery = query.trim();
+  ngOnInit() {
+    this.searchControl.valueChanges
+      .pipe(debounceTime(100), distinctUntilChanged(), takeUntil(this.destroy$))
+      .subscribe(searchTerm => {
+        // Skip search if user is selecting from autocomplete
+        if (this.isSelecting) {
+          this.isSelecting = false;
+          return;
+        }
+
+        this.search(searchTerm || undefined);
+      });
+  }
+
+  search(query: string | undefined) {
+    const trimmedQuery = (query ?? '').trim();
     if (trimmedQuery.length > 0) {
       this.reefSearchService.search({ query: trimmedQuery });
     } else {
@@ -27,7 +52,13 @@ export class ReefSearchComponent {
     }
   }
 
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   onReefSelected(event: any) {
+    this.isSelecting = true; // Set flag before selection
     const selectedReef = event.option.value;
     this.reefSelected.emit(selectedReef);
   }

--- a/packages/app/src/app/reef-map/reef-search/reef-search.component.ts
+++ b/packages/app/src/app/reef-map/reef-search/reef-search.component.ts
@@ -1,0 +1,39 @@
+import { Component, inject, output } from '@angular/core';
+import { ReefSearchService } from '../reef-search.service';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-reef-search',
+  imports: [MatAutocompleteModule, MatFormFieldModule, MatInputModule, MatIconModule],
+  templateUrl: './reef-search.component.html',
+  styleUrl: './reef-search.component.scss'
+})
+export class ReefSearchComponent {
+  public reefSearchService = inject(ReefSearchService);
+
+  // Output event for when a reef is selected
+  reefSelected = output<{ id: string; name: string }>();
+
+  search(query: string) {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length > 0) {
+      this.reefSearchService.search({ query: trimmedQuery });
+    } else {
+      // Clear results when input is empty
+      this.reefSearchService.results.set(undefined);
+    }
+  }
+
+  onReefSelected(event: any) {
+    const selectedReef = event.option.value;
+    this.reefSelected.emit(selectedReef);
+  }
+
+  // Display function for autocomplete - shows reef name instead of [Object object]
+  displayReef(reef: { id: string; name: string } | null): string {
+    return reef ? reef.name : '';
+  }
+}

--- a/packages/capacity-manager/src/index.ts
+++ b/packages/capacity-manager/src/index.ts
@@ -96,7 +96,7 @@ process.on('uncaughtException', error => {
 /**
  * Additional error handling for unhandled promise rejections
  */
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', (reason, _promise) => {
   const error = reason instanceof Error ? reason : new Error(String(reason));
   logger.error('Unhandled promise rejection:', error);
 

--- a/packages/infra/src/components/reefGuideFrontend.ts
+++ b/packages/infra/src/components/reefGuideFrontend.ts
@@ -204,11 +204,11 @@ export class ReefGuideFrontend extends Construct {
                     'rm -f packages/app/.env',
                     // Build the app using turbo
                     `npx turbo build --filter=${packageName}`,
-                    `ORIGINAL_PATH=$(pwd)`,
+                    'ORIGINAL_PATH=$(pwd)',
                     // Copy output files excluding map files
                     `cd ${outputPath} && find . -type f ! -name "*.js.map" ! -name "*.css.map" -exec cp --parents {} ${outputDir} \\;`,
                     // Return to where we were
-                    `cd $ORIGINAL_PATH`,
+                    'cd $ORIGINAL_PATH',
                     // Restore backup if it exists
                     '[ -f packages/app/backup.env ] && cp packages/app/backup.env packages/app/.env && rm packages/app/backup.env || echo "No .env backup to restore"'
                   ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       apache-arrow:
         specifier: ^21.0.0
         version: 21.0.0
+      fuzzysort:
+        specifier: ^3.1.0
+        version: 3.1.0
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
@@ -5444,6 +5447,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -14875,6 +14881,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fuzzysort@3.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
Allows local fuzzy-searching of the canonical reefs dataset (queried once for all name/ID fields from the ESRI service on initialisation). Selection flies the user to the reef, and makes the canonical reefs layer visible (if not already).

