### PR TITLE
Change assessment raster layer to interpolated color

### DIFF
--- a/packages/app/docs/openlayers_notes.md
+++ b/packages/app/docs/openlayers_notes.md
@@ -1,0 +1,38 @@
+# OpenLayers Notes
+
+
+# Style
+
+## Expressions
+
+WebGL raster layers can be styled using [Expressions](https://openlayers.org/en/latest/apidoc/module-ol_expr_expression.html#~ExpressionValue). This is a prefix math notation defined in JSON arrays that is compiled and executed on the GPU. It allows you to do various math on the color bands of your raster layer.
+
+
+
+Layer color bands are normalized by default so band values are 0 to 1. To prevent this, set `normalize: false` on the `Layer` `source`.
+
+AI seems to understand Openlayers expressions, so worth a try.
+
+### Examples
+
+There are a few expression examples. 
+*  [Band Contrast Stretch](https://openlayers.org/en/latest/examples/cog-stretch.html) - simple RGB math
+* [WebGL Shaded Relief](https://openlayers.org/en/latest/examples/webgl-shaded-relief.html) - hillshade, complex expressions composed together.
+
+### Interpolation
+
+An interpolation with 3 stops from red to green. The stop at zero is necessary to prevent the no-data values from showing as red. This 
+
+```javascript
+color: [
+  'interpolate',
+  ['linear'],
+  ['band', 1], // Band index
+  0, // no data value
+  [0, 0, 0, 0], // transparent
+  0.0001,
+  [255, 0, 0, 1], // color at band value +0
+  100,
+  [0, 255, 0, 1] // color at band value 1
+]
+```

--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -55,7 +55,7 @@ import Layer from 'ol/layer/Layer';
 import { createLayerFromDef } from '../../util/arcgis/arcgis-openlayer-util';
 import { LayerController, LayerControllerOptions } from '../map/openlayers-model';
 import { LayerProperties } from '../../types/layer.type';
-import { singleColorLayerStyle } from '../map/openlayers-styles';
+import { singleBandColorGradientLayerStyle } from '../map/openlayers-styles';
 import { fromString as colorFromString } from 'ol/color';
 
 /**
@@ -490,10 +490,10 @@ export class ReefGuideMapService {
             url: region.cogUrl
           }
         ],
-        // prevent normalization so can work with band value 1
+        // prevent normalization so can work with original band 1 values 0:100
         normalize: false
       }),
-      opacity: 0.8
+      opacity: 1.0
     });
 
     // free ObjectURL memory after layer disposed
@@ -511,7 +511,10 @@ export class ReefGuideMapService {
     // update style when color changes (and first init)
     effect(
       () => {
-        layer.setStyle(singleColorLayerStyle(colorFromString(layerController.color!())));
+        // ReefGuide assessment band values are 0 to 100
+        layer.setStyle(
+          singleBandColorGradientLayerStyle(colorFromString(layerController.color!()), 100)
+        );
       },
       { injector: this.injector }
     );

--- a/packages/app/src/app/map/openlayers-styles.ts
+++ b/packages/app/src/app/map/openlayers-styles.ts
@@ -2,7 +2,7 @@ import { Style } from 'ol/layer/WebGLTile';
 import { Color } from 'ol/color';
 
 /**
- * Set style on TileLayer that colors a specific band value.
+ * Create Style for WebGLTile layer that colors a specific band value.
  *
  * Note: for binary GeoTIFF with normalize=false the default targetValue=1 is correct.
  * @param color Color to use
@@ -15,5 +15,28 @@ export function singleColorLayerStyle(color: Color, targetValue = 1): Style {
     color: ['case', ['==', value, targetValue], color, [0, 0, 0, 0]]
     // Note: var within color value doesn't work, so can't use style variables
     // color: ['case', ['==', value, targetValue], [ 0, ['var', 'g'], 0, 1], [0, 0, 0, 0]]
+  };
+}
+
+/**
+ * Create Style for WebGLTile layer that interpolates band 1 values against the given
+ * color's alpha channel.
+ *
+ * @param color Color for the target value
+ * @param targetValue end color value (default 1)
+ */
+export function singleBandColorGradientLayerStyle(color: Color, targetValue = 1): Style {
+  // start with transparent version of the color.
+  const startColor = [color[0], color[1], color[2], 0];
+  return {
+    color: [
+      'interpolate',
+      ['linear'],
+      ['band', 1], // Band index
+      0, // no value
+      startColor,
+      targetValue,
+      color
+    ]
   };
 }


### PR DESCRIPTION
Update OpenLayers style expression to work with new ReefGuide COG format.
fixes #185 

<img width="693" height="636" alt="image" src="https://github.com/user-attachments/assets/602e1292-0d42-4e7e-bf32-a8089095ada4" />

<img width="716" height="644" alt="image" src="https://github.com/user-attachments/assets/18a7f16d-2059-4f9f-8373-9a7e662236a6" />


