### PR TITLE
Project Tiles: only show public icon, increase size, green

### DIFF
--- a/packages/app/src/app/projects/projects-list/projects-list.component.html
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.html
@@ -153,13 +153,6 @@
                     matTooltip="Public: visible to everyone."
                     >public</mat-icon
                   >
-                } @else {
-                  <mat-icon
-                    class="public-icon"
-                    #tooltip="matTooltip"
-                    matTooltip="Private: visible only to shared users."
-                    >public_off</mat-icon
-                  >
                 }
               </div>
               @if (canManageProjectSettings(project)) {

--- a/packages/app/src/app/projects/projects-list/projects-list.component.scss
+++ b/packages/app/src/app/projects/projects-list/projects-list.component.scss
@@ -426,8 +426,8 @@
         align-items: center;
 
         .public-icon {
-          font-size: large;
-          color: #666;
+          // TODO share color variable with Project Settings
+          color: #4caf50;
         }
 
         @media (max-width: 480px) {


### PR DESCRIPTION
Change design to make public projects standout.

<img width="1218" height="590" alt="image" src="https://github.com/user-attachments/assets/39bdd63f-6bc3-48b9-8c93-53806982256d" />
