### PR TITLE
feat: job expiry (cron, route, CLI)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -302,6 +302,53 @@ The system provides detailed error reporting:
    ❌ user@example.com - Error: Failed to update user roles: Unauthorized
 ```
 
+## Job Timeout Management
+
+The job timeout system allows administrators to clean up stale jobs that have been stuck in non-terminal states (PENDING or IN_PROGRESS) for too long.
+
+#### `job-timeout run`
+
+Timeout jobs that have been stuck in PENDING or IN_PROGRESS state for longer than a specified threshold.
+
+```bash
+# Timeout all jobs older than 60 minutes (default)
+pnpm start job-timeout run
+
+# Timeout jobs older than 2 hours (120 minutes)
+pnpm start job-timeout run --minutes 120
+pnpm start job-timeout run -m 120
+
+# Timeout only specific job types older than 30 minutes
+pnpm start job-timeout run -m 30 -t SUITABILITY_ASSESSMENT REGIONAL_ASSESSMENT
+
+# Timeout TEST jobs older than 5 minutes
+pnpm start job-timeout run -m 5 --types TEST
+```
+
+**Options:**
+
+- `-m, --minutes <minutes>`: Timeout threshold in minutes (default: 60). Jobs older than this will be timed out
+- `-t, --types <types...>`: Optional job types to timeout (e.g., `SUITABILITY_ASSESSMENT`, `REGIONAL_ASSESSMENT`, `TEST`, `ADRIA_MODEL_RUN`)
+
+**Output Example:**
+
+```bash
+⏱️  Timing out jobs older than 120 minutes...
+   Filtering by job types: SUITABILITY_ASSESSMENT, REGIONAL_ASSESSMENT
+
+📊 Results:
+   Total jobs timed out: 5
+
+   Breakdown by job type:
+      SUITABILITY_ASSESSMENT: 3
+      REGIONAL_ASSESSMENT: 2
+
+   Timed out job IDs:
+      142, 156, 187, 201, 215
+
+✅ Job timeout process completed successfully.
+```
+
 ## Environment Variables
 
 Set these environment variables to avoid interactive prompts:

--- a/packages/cli/src/commands/job-timeout.ts
+++ b/packages/cli/src/commands/job-timeout.ts
@@ -1,0 +1,116 @@
+import { Command } from 'commander';
+import { ApiClientService } from '../services/api-client';
+import { JobType } from '@reefguide/db';
+import { PostTimeoutJobsResponse } from '@reefguide/types';
+
+/**
+ * Trigger job timeout process
+ */
+async function timeoutJobs(
+  apiClient: ApiClientService,
+  timeoutThresholdMinutes: number,
+  jobTypes?: JobType[]
+): Promise<PostTimeoutJobsResponse> {
+  try {
+    console.log(`⏱️  Timing out jobs older than ${timeoutThresholdMinutes} minutes...`);
+    if (jobTypes && jobTypes.length > 0) {
+      console.log(`   Filtering by job types: ${jobTypes.join(', ')}`);
+    }
+
+    const response = await apiClient.client.post<PostTimeoutJobsResponse>(
+      `${apiClient.apiBaseUrl}/admin/timeout-jobs`,
+      {
+        timeoutThresholdMinutes,
+        jobTypes
+      }
+    );
+
+    return response.data;
+  } catch (error: any) {
+    if (error.response?.status === 401) {
+      throw new Error('Unauthorized - invalid token or insufficient permissions');
+    }
+    throw new Error(`Failed to timeout jobs: ${error.response?.data?.message || error.message}`);
+  }
+}
+
+/**
+ * Command: Timeout stale jobs
+ */
+async function runTimeoutJobs(timeoutThresholdMinutes: number, jobTypes?: string[]): Promise<void> {
+  try {
+    console.log('🔍 Starting job timeout process...\n');
+
+    const apiClient = new ApiClientService();
+    await apiClient.initialize();
+
+    // Validate and convert job types if provided
+    let validatedJobTypes: JobType[] | undefined;
+    if (jobTypes && jobTypes.length > 0) {
+      const validJobTypes = Object.values(JobType);
+      validatedJobTypes = jobTypes.map(type => {
+        const upperType = type.toUpperCase();
+        if (!validJobTypes.includes(upperType as JobType)) {
+          throw new Error(
+            `Invalid job type: ${type}. Valid types are: ${validJobTypes.join(', ')}`
+          );
+        }
+        return upperType as JobType;
+      });
+    }
+
+    // Execute timeout
+    const result = await timeoutJobs(apiClient, timeoutThresholdMinutes, validatedJobTypes);
+
+    // Display results
+    console.log('\n📊 Results:');
+    console.log(`   Total jobs timed out: ${result.totalTimedOut}`);
+
+    if (result.totalTimedOut > 0) {
+      console.log('\n   Breakdown by job type:');
+      Object.entries(result.byType).forEach(([type, count]) => {
+        console.log(`      ${type}: ${count}`);
+      });
+
+      console.log('\n   Timed out job IDs:');
+      console.log(`      ${result.timedOutJobIds.join(', ')}`);
+    } else {
+      console.log('\n   No jobs needed to be timed out.');
+    }
+
+    console.log('\n✅ Job timeout process completed successfully.');
+  } catch (error: any) {
+    console.error(`\n❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Create job timeout commands
+ */
+export function createJobTimeoutCommands(program: Command): void {
+  const jobTimeout = program
+    .command('job-timeout')
+    .description('Manage job timeouts for stale jobs');
+
+  jobTimeout
+    .command('run')
+    .description('Timeout jobs that have been stuck in PENDING or IN_PROGRESS state')
+    .option(
+      '-m, --minutes <minutes>',
+      'Timeout threshold in minutes (jobs older than this will be timed out)',
+      '60'
+    )
+    .option(
+      '-t, --types <types...>',
+      'Optional: Specific job types to timeout (e.g., SUITABILITY_ASSESSMENT REGIONAL_ASSESSMENT)'
+    )
+    .action(async options => {
+      const minutes = parseInt(options.minutes, 10);
+      if (isNaN(minutes) || minutes <= 0) {
+        console.error('❌ Error: Minutes must be a positive number');
+        process.exit(1);
+      }
+      await runTimeoutJobs(minutes, options.types);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { createDataSpecCommands } from './commands/data-spec';
 import { createPreapprovalCommands } from './commands/pre-approval';
 import { createUserAuditCommands } from './commands/user-audit';
 import { createCacheManagementCommands } from './commands/cache-management';
+import { createJobTimeoutCommands } from './commands/job-timeout';
 
 // Load environment variables
 dotenv.config();
@@ -20,6 +21,7 @@ createDataSpecCommands(program);
 createPreapprovalCommands(program);
 createUserAuditCommands(program);
 createCacheManagementCommands(program);
+createJobTimeoutCommands(program);
 
 // Parse command line arguments
 program.parse();

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1137,3 +1137,21 @@ export const DeleteNoteResponseSchema = z.object({
   message: z.string()
 });
 export type DeleteNoteResponse = z.infer<typeof DeleteNoteResponseSchema>;
+
+// Job timeout
+export const PostTimeoutJobsRequestSchema = z.object({
+  // 2 hour default
+  timeoutThresholdMinutes: z.number().positive().default(120),
+  jobTypes: z.array(z.nativeEnum(JobType)).optional()
+});
+export type PostTimeoutJobsRequest = z.infer<typeof PostTimeoutJobsRequestSchema>;
+
+export const PostTimeoutJobsResponseSchema = z.object({
+  /** Total number of jobs that were timed out */
+  totalTimedOut: z.number(),
+  /** Breakdown by job type */
+  byType: z.record(z.nativeEnum(JobType), z.number()),
+  /** IDs of all jobs that were timed out */
+  timedOutJobIds: z.array(z.number())
+});
+export type PostTimeoutJobsResponse = z.infer<typeof PostTimeoutJobsResponseSchema>;

--- a/packages/web-api/src/admin/helpers.ts
+++ b/packages/web-api/src/admin/helpers.ts
@@ -1,0 +1,96 @@
+import { JobStatus, JobType, prisma } from '@reefguide/db';
+import { PostTimeoutJobsResponse } from '@reefguide/types';
+
+/**
+ * Options for timing out jobs
+ */
+export interface TimeoutJobsOptions {
+  /** Threshold in minutes - jobs older than this will be timed out */
+  timeoutThresholdMinutes: number;
+  /** Optional array of specific job types to check. If not provided, checks all types */
+  jobTypes?: JobType[];
+}
+
+/**
+ * Times out jobs that have been in non-terminal states for too long.
+ *
+ * This function finds jobs that are PENDING or IN_PROGRESS and older than
+ * the specified threshold, then sets their status to TIMED_OUT.
+ *
+ * @param options - Configuration for timeout operation
+ * @returns Metadata about timed out jobs
+ */
+export async function timeoutJobs(options: TimeoutJobsOptions): Promise<PostTimeoutJobsResponse> {
+  const { timeoutThresholdMinutes, jobTypes } = options;
+
+  // Calculate the cutoff time
+  const currentTime = new Date();
+  const timeoutThresholdMs = timeoutThresholdMinutes * 60 * 1000;
+  const cutoffTime = new Date(currentTime.getTime() - timeoutThresholdMs);
+
+  // Build the where clause
+  const whereClause: any = {
+    status: {
+      in: [JobStatus.PENDING, JobStatus.IN_PROGRESS]
+    },
+    created_at: {
+      lt: cutoffTime
+    }
+  };
+
+  // If specific job types are provided, filter by them
+  if (jobTypes && jobTypes.length > 0) {
+    whereClause.type = {
+      in: jobTypes
+    };
+  }
+
+  // Find all jobs that need to be timed out
+  const jobsToTimeout = await prisma.job.findMany({
+    where: whereClause,
+    select: {
+      id: true,
+      type: true
+    }
+  });
+
+  // If no jobs to timeout, return early
+  if (jobsToTimeout.length === 0) {
+    return {
+      totalTimedOut: 0,
+      byType: {} as Record<JobType, number>,
+      timedOutJobIds: []
+    };
+  }
+
+  // Extract job IDs
+  const jobIds = jobsToTimeout.map(job => job.id);
+
+  // Update all jobs to TIMED_OUT status
+  await prisma.job.updateMany({
+    where: {
+      id: {
+        in: jobIds
+      }
+    },
+    data: {
+      status: JobStatus.TIMED_OUT,
+      updated_at: new Date()
+    }
+  });
+
+  // Calculate breakdown by type
+  const byType: Record<JobType, number> = {} as Record<JobType, number>;
+  jobsToTimeout.forEach(job => {
+    if (!byType[job.type]) {
+      byType[job.type] = 0;
+    }
+    byType[job.type]++;
+  });
+
+  return {
+    totalTimedOut: jobsToTimeout.length,
+    byType,
+    timedOutJobIds: jobIds
+  };
+}

--- a/packages/web-api/src/config.ts
+++ b/packages/web-api/src/config.ts
@@ -28,6 +28,14 @@ const envSchema = z.object({
   WORKER_PASSWORD: z.string(),
   ADMIN_USERNAME: z.string(),
   ADMIN_PASSWORD: z.string(),
+  JOB_EXPIRY_MINUTES: z
+    .string()
+    .optional()
+    .default('120')
+    .transform(val => parseInt(val, 10))
+    .refine(val => !isNaN(val) && val > 0, {
+      message: 'JOB_EXPIRY_MINUTES must be a positive number'
+    }),
   DISABLE_CACHE: z
     .string()
     .default('false')
@@ -182,6 +190,8 @@ export interface Config {
   };
   // Optional Sentry DSN for error tracking
   sentryDsn?: string;
+  // How many minutes before non-terminated jobs expire
+  jobExpiryMinutes: number;
 }
 
 /**
@@ -303,7 +313,8 @@ export function getConfig(): Config {
       config: emailConfig,
       smtp: smtpConfig
     },
-    sentryDsn: env.SENTRY_DSN
+    sentryDsn: env.SENTRY_DSN,
+    jobExpiryMinutes: env.JOB_EXPIRY_MINUTES
   };
 
   // Update process.env with parsed values


### PR DESCRIPTION
Implements a CRON job, API endpoint and CLI command to move jobs which are greater than a threshold old to the TIMED_OUT state, when they are either IN_PROGRESS or PENDING.