### PR TITLE
fix layer download buttons

### DIFF
--- a/packages/app/src/app/location-selection/polygon-map.service.ts
+++ b/packages/app/src/app/location-selection/polygon-map.service.ts
@@ -287,13 +287,13 @@ export class PolygonMapService {
     // Create new vector layer
     const source = new VectorSource();
 
-    const layerTitle = `Project Polygons`;
+    const download = () => this.download();
 
     const layer = new VectorLayer({
       properties: {
-        title: layerTitle,
+        title: 'Project Polygons',
         id: USER_POLYGON_LAYER_ID,
-        download: () => this.download()
+        download
         // Alternative, but won't work without cookies-based auth or token in URL
         // downloadUrl: this.api.getPolygonsFileUrl({ projectId: this.currentProjectId })
       } satisfies LayerProperties,
@@ -302,6 +302,10 @@ export class PolygonMapService {
     });
 
     layerGroup.getLayers().push(layer);
+
+    // set on group so download button displays in layer list
+    layerGroup.set('download', download);
+
     return layer;
   }
 
@@ -330,11 +334,9 @@ export class PolygonMapService {
       return existingLayerGroup;
     }
 
-    const groupTitle = `Project ${projectId} Polygons`;
-
     const layerGroup = new LayerGroup({
       properties: {
-        title: groupTitle
+        title: 'Project Polygons'
       }
     });
 

--- a/packages/app/src/app/location-selection/reef-guide-map.service.ts
+++ b/packages/app/src/app/location-selection/reef-guide-map.service.ts
@@ -763,11 +763,13 @@ export class ReefGuideMapService {
 
     const color = '#F1C00C';
 
+    // cogUrl could be a Blob URL, we want to send users to the original
+    const downloadUrl = region.originalUrl;
+
     const layer = new TileLayer({
       properties: {
         title: `${region.region} criteria assessment`,
-        // cogUrl could be Blob URL, we want to send users to the original
-        downloadUrl: region.originalUrl
+        downloadUrl
       } satisfies LayerProperties,
       source: new GeoTIFF({
         interpolate: false,
@@ -806,6 +808,11 @@ export class ReefGuideMapService {
     );
 
     layerGroup.getLayers().push(layer);
+
+    // set downloadUrl on the group so that the layer list shows download button.
+    // this will be a problem if we return to multiple layers in the layer group,
+    // but that requires a UI and download system redesign anyway.
+    layerGroup.set('downloadUrl', downloadUrl);
   }
 
   private addSuitabilityAssessmentLayer(
@@ -846,6 +853,9 @@ export class ReefGuideMapService {
     this.afterCreateLayer(layer);
 
     layerGroup.getLayers().push(layer);
+
+    // set downloadUrl on group so layer list shows download button
+    layerGroup.set('downloadUrl', url);
   }
 
   private async addCriteriaLayers() {


### PR DESCRIPTION
fix download buttons for project polygons and site assessment.

This was caused by changing from layer list displaying all leaf layers to the root layers a while ago.
