### PR TITLE
fix tsx missing during cdk deploy

### DIFF
--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@sentry/cli": "^2.53.0",
     "@types/express": "catalog:",
+    "tsx": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "read": "^4.1.0"
   },
   "devDependencies": {
+    "tsx": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/example-worker/package.json
+++ b/packages/example-worker/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/express": "catalog:",
+    "tsx": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -32,6 +32,7 @@
     "@types/supertest": "^6.0.3",
     "aws-cdk": "2.1101.0",
     "cdk-dia": "^0.12.1",
+    "tsx": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       '@types/express':
         specifier: 'catalog:'
         version: 4.17.25
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -272,6 +275,9 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
     devDependencies:
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -343,6 +349,9 @@ importers:
       '@types/express':
         specifier: 'catalog:'
         version: 4.17.25
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -392,6 +401,9 @@ importers:
       cdk-dia:
         specifier: ^0.12.1
         version: 0.12.3
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
🚀 Starting CDK deployment...
Command: pnpm exec cdk deploy --require-approval never
undefined
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "tsx" not found


Can't repro locally, only happens with GitHub action.