### PR TITLE
Fix ECS services web-api and capacity-manager

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,28 +17,38 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+
       - name: Use Node.js 24 with pnpm cache
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
+
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
       - name: Copy web-api environment file and set test mode
         run: cd packages/web-api && cp .env.dist .env && echo -en "\nTEST_MODE=true" >> .env
+
         # TODO ideally, would configure packages/db and Prisma to use above env
       - name: Copy db environment file and set test mode
         run: cd packages/db && cp .env.dist .env && echo -en "\nTEST_MODE=true" >> .env
+
       - name: Prisma generate
         run: pnpm run generate
+
       - name: Run typecheck
         run: pnpm run type-check
+
       - name: Run linter
         run: pnpm run lint -- --verbose --output-logs=full
+
       - name: Start Docker services (PostgreSQL DB)
         run: docker compose up -d
+
       - name: Wait for PostgreSQL to be ready
         run: |
           # Use pg_isready to check if PostgreSQL is accepting connections
@@ -56,12 +66,16 @@ jobs:
           fi
 
           echo "PostgreSQL is ready!"
+
       - name: Generate local keys
         run: cd packages/web-api && pnpm run local-keys
+
       - name: Reset database
         run: cd packages/db && cp .env.dist .env && pnpm run db-reset
+
       - name: Run tests
         # TODO expand to other packages
-        run: npx turbo test --filter=@reefguide/web-api
+        run: pnpm turbo test --filter=@reefguide/web-api
+
       - name: Stop Docker services
         run: docker compose down

--- a/.github/workflows/deploy-aws-cdk.yml
+++ b/.github/workflows/deploy-aws-cdk.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo "📦 Installing project dependencies..."
-          pnpm install
+          pnpm install --frozen-lockfile --strict-peer-dependencies
           echo "✅ Dependencies installed successfully"
 
       - name: Build the infra package

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -15,21 +15,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+
       - name: Setup Node.js 24 with pnpm cache
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
+
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
       - name: Copy db environment file and set test mode
         run: cd packages/db && cp .env.dist .env && echo -en "\nTEST_MODE=true" >> .env
+
       - name: Prisma generate
         run: pnpm run generate
+
       - name: Check formatting and lint
         run: pnpm run format:check
+
       - name: Comment on PR if formatting issues found
         if: failure()
         uses: actions/github-script@v9

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG APP_NAME
 WORKDIR /app
 COPY . .
 # Generate a partial monorepo with only the files needed for the target app
-RUN turbo prune --scope=${APP_NAME} --docker
+RUN turbo prune --docker ${APP_NAME}
 
 FROM base AS installer
 ARG APP_NAME
@@ -22,7 +22,7 @@ COPY .gitignore .gitignore
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm clean-install
 
 # Grab the root tsconfig too (before building)
 COPY tsconfig.json ./tsconfig.json
@@ -64,7 +64,7 @@ EXPOSE ${PORT}
 ## COPY --from=installer /app/packages/${PACKAGE_NAME}/node_modules ./dist/packages/${PACKAGE_NAME}
 ## COPY --from=installer /app/node_modules ./node_modules
 #
-#COPY 
+#COPY
 #
 #EXPOSE ${PORT}
 #ENV PORT=${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ COPY tsconfig.json ./tsconfig.json
 COPY --from=pruner /app/out/full/ .
 COPY turbo.json turbo.json
 
-# Generate client before build
-RUN pnpm run generate
-
 # Build target
 RUN turbo build --filter=${APP_NAME}
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "packageManager": "pnpm@11.1.3",
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "catalog:",
     "typescript-eslint": "^8.59.2"
   },
-  "packageManager": "pnpm@11.1.3",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=24.0.0",
     "pnpm": ">=11.1.1"

--- a/packages/capacity-manager/README.md
+++ b/packages/capacity-manager/README.md
@@ -74,6 +74,11 @@ The service exposes a health check endpoint at `/health` on port 3000 (or `PORT`
 **Note:** if capacity-manager errors on startup, the ECS configuration will never become
 healthy and the cdk deployment will fail with a circuit breaker error.
 
+In this situation try these steps one at a time, re-trying cdk deploy after each:
+
+1. check **web-api** and **capacity-manager** logs for errors
+2. set service tasks to `0` (see [debugging reefguide](../../docs/debugging-reefguide.md))
+
 ## Logging
 
 Logs are output to console with configurable levels via the `LOG_LEVEL` environment variable:

--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -5,15 +5,16 @@
   "type": "module",
   "scripts": {
     "start": "env-cmd tsx src/index.ts",
+    "start-build": "env-cmd node build/src/index.js",
     "watch": "tsc -w",
-    "build": "tsc",
+    "build": "tsup src/index.ts --format esm --out-dir build/src --no-splitting --sourcemap",
     "lint": "gts lint",
     "type-check": "tsc --noEmit",
     "format:write": "prettier --write \"{src,test}/**/*.{ts,js,json,html,scss,md}\" \"!**/node_modules/**\" \"!**/dist/**\"",
     "format:check": "prettier --check \"{src,test}/**/*.{ts,js,json,html,scss,md}\" \"!**/node_modules/**\" \"!**/dist/**\"",
     "clean": "gts clean",
     "fix": "gts fix",
-    "sourcemaps": "tsc && ./node_modules/@sentry/cli/bin/sentry-cli sourcemaps inject build/src && ./node_modules/@sentry/cli/bin/sentry-cli --url ${SENTRY_URL} sourcemaps --org none --project none upload build/src/"
+    "sourcemaps": "tsup src/index.ts --format esm --out-dir build/src --no-splitting --sourcemap && ./node_modules/@sentry/cli/bin/sentry-cli sourcemaps inject build/src && ./node_modules/@sentry/cli/bin/sentry-cli --url ${SENTRY_URL} sourcemaps --org none --project none upload build/src/"
   },
   "keywords": [],
   "author": "AIMS",
@@ -35,6 +36,7 @@
     "@reefguide/types": "workspace:*",
     "@sentry/cli": "^2.53.0",
     "@types/express": "catalog:",
+    "tsup": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-ecs": "^3.835.0",
     "@reefguide/db": "workspace:*",
     "@reefguide/types": "workspace:*",
-    "@sentry/node": "^10.4.0",
+    "@sentry/node": "catalog:",
     "axios": "catalog:",
     "env-cmd": "^10.1.0",
     "express": "catalog:",

--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -29,7 +29,7 @@
     "express": "catalog:",
     "jwt-decode": "^4.0.0",
     "winston": "^3.17.0",
-    "winston-transport-sentry-node": "^3.0.0",
+    "winston-sentry-javascript-node": "^0.2.2",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reefguide/capacity-manager",
-  "version": "0.1",
+  "version": "0.1.1",
   "description": "Capacity manager for the ReefGuide job system.",
   "type": "module",
   "scripts": {

--- a/packages/capacity-manager/package.json
+++ b/packages/capacity-manager/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/client-ec2": "^3.836.0",
     "@aws-sdk/client-ecs": "^3.835.0",
     "@reefguide/db": "workspace:*",
-    "@reefguide/types": "workspace:*",
     "@sentry/node": "catalog:",
     "axios": "catalog:",
     "env-cmd": "^10.1.0",
@@ -33,6 +32,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@reefguide/types": "workspace:*",
     "@sentry/cli": "^2.53.0",
     "@types/express": "catalog:",
     "tsx": "catalog:",

--- a/packages/capacity-manager/src/authClient.ts
+++ b/packages/capacity-manager/src/authClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { jwtDecode } from 'jwt-decode';
-import { logger } from './logging';
+import { logger } from './logging.js';
 
 /**
  * Interface for authentication credentials

--- a/packages/capacity-manager/src/authClient.ts
+++ b/packages/capacity-manager/src/authClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { jwtDecode } from 'jwt-decode';
-import { logger } from './logging.js';
+import { logger } from './logging';
 
 /**
  * Interface for authentication credentials

--- a/packages/capacity-manager/src/index.ts
+++ b/packages/capacity-manager/src/index.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/node';
 import express from 'express';
-import { config } from './config.js';
-import { CapacityManager } from './manager.js';
-import { AuthApiClient } from './authClient.js';
-import { logger } from './logging.js';
+import { config } from './config';
+import { CapacityManager } from './manager';
+import { AuthApiClient } from './authClient';
+import { logger } from './logging';
 
 /**
  * Main entry point for the Capacity Manager service

--- a/packages/capacity-manager/src/index.ts
+++ b/packages/capacity-manager/src/index.ts
@@ -1,9 +1,9 @@
-import express from 'express';
-import { config } from './config';
-import { CapacityManager } from './manager';
-import { AuthApiClient } from './authClient';
-import { logger } from './logging';
 import * as Sentry from '@sentry/node';
+import express from 'express';
+import { config } from './config.js';
+import { CapacityManager } from './manager.js';
+import { AuthApiClient } from './authClient.js';
+import { logger } from './logging.js';
 
 /**
  * Main entry point for the Capacity Manager service

--- a/packages/capacity-manager/src/logging.ts
+++ b/packages/capacity-manager/src/logging.ts
@@ -1,7 +1,7 @@
 import winston from 'winston';
 import type { Logger, LoggerOptions } from 'winston';
 import { config } from './config';
-import SentryTransport from 'winston-transport-sentry-node';
+import { SentryTransport } from 'winston-sentry-javascript-node';
 
 /**
  * Winston logger configuration

--- a/packages/capacity-manager/src/logging.ts
+++ b/packages/capacity-manager/src/logging.ts
@@ -1,6 +1,6 @@
 import winston from 'winston';
 import type { Logger, LoggerOptions } from 'winston';
-import { config } from './config';
+import { config } from './config.js';
 import { SentryTransport } from 'winston-sentry-javascript-node';
 
 /**

--- a/packages/capacity-manager/src/logging.ts
+++ b/packages/capacity-manager/src/logging.ts
@@ -1,7 +1,7 @@
 import winston from 'winston';
 import type { Logger, LoggerOptions } from 'winston';
-import { config } from './config.js';
 import { SentryTransport } from 'winston-sentry-javascript-node';
+import { config } from './config';
 
 /**
  * Winston logger configuration

--- a/packages/capacity-manager/src/manager.ts
+++ b/packages/capacity-manager/src/manager.ts
@@ -6,9 +6,9 @@ import {
   Task
 } from '@aws-sdk/client-ecs';
 import { EC2Client, DescribeSubnetsCommand } from '@aws-sdk/client-ec2';
-import { Config, ConfigSchema, JobTypeConfig } from './config.js';
-import { AuthApiClient } from './authClient.js';
-import { logger } from './logging.js';
+import { Config, ConfigSchema, JobTypeConfig } from './config';
+import { AuthApiClient } from './authClient';
+import { logger } from './logging';
 import { JobType } from '@reefguide/db';
 import type { PollJobsResponse } from '@reefguide/types';
 

--- a/packages/capacity-manager/src/manager.ts
+++ b/packages/capacity-manager/src/manager.ts
@@ -6,11 +6,11 @@ import {
   Task
 } from '@aws-sdk/client-ecs';
 import { EC2Client, DescribeSubnetsCommand } from '@aws-sdk/client-ec2';
-import { Config, ConfigSchema, JobTypeConfig } from './config';
-import { AuthApiClient } from './authClient';
+import { Config, ConfigSchema, JobTypeConfig } from './config.js';
+import { AuthApiClient } from './authClient.js';
+import { logger } from './logging.js';
 import { JobType } from '@reefguide/db';
-import { logger } from './logging';
-import { PollJobsResponse } from '@reefguide/types';
+import type { PollJobsResponse } from '@reefguide/types';
 
 /**
  * Interface for tracking worker status

--- a/packages/capacity-manager/tsconfig.json
+++ b/packages/capacity-manager/tsconfig.json
@@ -6,7 +6,9 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "sourceMap": true,
-        "inlineSources": true
+        "inlineSources": true,
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext"
     },
     "include": [
         "src/**/*.ts"

--- a/packages/capacity-manager/tsconfig.json
+++ b/packages/capacity-manager/tsconfig.json
@@ -1,16 +1,14 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "rootDir": ".",
-        "outDir": "build",
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "sourceMap": true,
-        "inlineSources": true,
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext"
-    },
-    "include": [
-        "src/**/*.ts"
-    ]
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "module": "Preserve",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.971.0",
-    "@types/jest": "^29.5.12",
     "@types/node": "catalog:",
     "@types/supertest": "^6.0.3",
     "aws-cdk": "2.1101.0",

--- a/packages/web-api/.env.dist
+++ b/packages/web-api/.env.dist
@@ -1,24 +1,36 @@
 NODE_ENV=development
+
+# change both PORT and API_DOMAIN if you want web-api server listening on another port
 PORT=5000
+API_DOMAIN=http://localhost:5000
+
 # if you get a connection error, try 127.0.0.1 instead of localhost
 DATABASE_URL=postgresql://admin:password@localhost:5432/postgres?schema=public
 DIRECT_URL=postgresql://admin:password@localhost:5432/postgres?schema=public
+
 # keys
 JWT_PRIVATE_KEY=TODO
 JWT_PUBLIC_KEY=TODO
 JWT_KEY_ID=TODO
-API_DOMAIN=http://localhost:5000
+
+# Enable Sentry
+# SENTRY_DSN=https://example.com
+
+# AWS / Minio
 AWS_REGION=ap-southeast-2
+
+S3_BUCKET_NAME=replace-me
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_USERNAME=minioadmin
+MINIO_PASSWORD=minioadmin
+
+# Default account credentials
 ADMIN_USERNAME=admin@email.com
 ADMIN_PASSWORD=password
 MANAGER_USERNAME=manager@email.com
 MANAGER_PASSWORD=password
 WORKER_USERNAME=worker@email.com
 WORKER_PASSWORD=password
-S3_BUCKET_NAME=replace-me
-MINIO_ENDPOINT=http://localhost:9000
-MINIO_USERNAME=minioadmin
-MINIO_PASSWORD=minioadmin
 
 # Email Configuration - Using MOCK service for development
 EMAIL_SERVICE_MODE=MOCK

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@reefguide/web-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "REST API to support ReefGuide AIMS.",
   "type": "module",
   "scripts": {
     "start": "env-cmd tsx src/index.ts",
+    "start-build": "env-cmd node build/src/index.js",
     "watch": "tsc -w",
     "dev": "env-cmd tsx watch src/index.ts",
     "preapi": "env-cmd tsx scripts/waitForPort.ts",
     "api": "env-cmd tsx src/index.ts",
-    "build": "tsc",
+    "build": "tsup src/index.ts --format esm --out-dir build/src --no-splitting --sourcemap",
     "lint": "gts lint",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
@@ -19,7 +20,7 @@
     "fix": "gts fix",
     "local-keys": "tsx scripts/localKeys.ts",
     "start-web-api-docker": "tsx src/index.ts",
-    "sourcemaps": "tsc && ./node_modules/@sentry/cli/bin/sentry-cli sourcemaps inject build/src && ./node_modules/@sentry/cli/bin/sentry-cli --url ${SENTRY_URL} sourcemaps --org none --project none upload build/src/"
+    "sourcemaps": "tsup src/index.ts --format esm --out-dir build/src --no-splitting --sourcemap && ./node_modules/@sentry/cli/bin/sentry-cli sourcemaps inject build/src && ./node_modules/@sentry/cli/bin/sentry-cli --url ${SENTRY_URL} sourcemaps --org none --project none upload build/src/"
   },
   "keywords": [],
   "author": "AIMS",
@@ -74,6 +75,7 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.3",
     "supertest": "^7.2.2",
+    "tsup": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -34,7 +34,7 @@
     "@maphubs/tokml": "^0.6.1",
     "@reefguide/db": "workspace:*",
     "@reefguide/types": "workspace:*",
-    "@sentry/node": "^10.4.0",
+    "@sentry/node": "catalog:",
     "@types/aws-lambda": "^8.10.150",
     "aws-cdk-lib": "2.202.0",
     "axios": "catalog:",
@@ -66,7 +66,6 @@
     "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2.8.19",
     "@types/express": "catalog:",
-
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
     "@types/node-cron": "^3.0.11",

--- a/packages/web-api/tsconfig.json
+++ b/packages/web-api/tsconfig.json
@@ -3,9 +3,10 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "typeRoots": ["./node_modules/@types", "src/types/express/"],
     "sourceMap": true,
     "inlineSources": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@sentry/node':
+      specifier: ^10.53.1
+      version: 10.53.1
     '@types/express':
       specifier: ^4.17.25
       version: 4.17.25
@@ -205,7 +208,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@sentry/node':
-        specifier: ^10.4.0
+        specifier: 'catalog:'
         version: 10.53.1
       axios:
         specifier: 'catalog:'
@@ -460,7 +463,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@sentry/node':
-        specifier: ^10.4.0
+        specifier: 'catalog:'
         version: 10.53.1
       '@types/aws-lambda':
         specifier: ^8.10.150

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ importers:
       '@reefguide/db':
         specifier: workspace:*
         version: link:../db
-      '@reefguide/types':
-        specifier: workspace:*
-        version: link:../types
       '@sentry/node':
         specifier: 'catalog:'
         version: 10.53.1
@@ -232,6 +229,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
+      '@reefguide/types':
+        specifier: workspace:*
+        version: link:../types
       '@sentry/cli':
         specifier: ^2.53.0
         version: 2.58.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ catalogs:
       version: 3.8.3
     tsx:
       specifier: ^4.22.0
-      version: 4.22.0
+      version: 4.22.1
     typescript:
       specifier: ~5.9.3
       version: 5.9.3
@@ -112,7 +112,7 @@ importers:
         version: 20.3.21(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(rxjs@7.8.2)
       '@ngx-env/builder':
         specifier: ^20.1.1
-        version: 20.1.1(@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.0)(typescript@5.9.3))(webpack@5.105.0(postcss@8.5.12))
+        version: 20.1.1(@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.1)(typescript@5.9.3))(webpack@5.105.0(postcss@8.5.12))
       '@reefguide/db':
         specifier: workspace:*
         version: link:../db
@@ -158,7 +158,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^20.3.9
-        version: 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(tsx@4.22.0)(typescript@5.9.3)
+        version: 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(tsx@4.22.1)(typescript@5.9.3)
       '@angular/cli':
         specifier: ^20.3.9
         version: 20.3.26(@types/node@25.8.0)(chokidar@4.0.3)
@@ -240,7 +240,7 @@ importers:
         version: 4.17.25
       tsx:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -280,7 +280,7 @@ importers:
     devDependencies:
       tsx:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -320,7 +320,7 @@ importers:
         version: 6.19.3(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -354,7 +354,7 @@ importers:
         version: 4.17.25
       tsx:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -403,7 +403,7 @@ importers:
         version: 0.12.3
       tsx:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -428,7 +428,7 @@ importers:
         version: 3.8.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -579,13 +579,13 @@ importers:
         version: 7.2.2
       tsx:
         specifier: 'catalog:'
-        version: 4.22.0
+        version: 4.22.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1))
 
 packages:
 
@@ -7490,8 +7490,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.22.0:
-    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+  tsx@4.22.1:
+    resolution: {integrity: sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -8217,13 +8217,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(tsx@4.22.0)(typescript@5.9.3)':
+  '@angular-devkit/build-angular@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(tsx@4.22.1)(typescript@5.9.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.26(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2003.26(chokidar@4.0.3)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(postcss@8.5.12)))(webpack@5.105.0(postcss@8.5.12))
       '@angular-devkit/core': 20.3.26(chokidar@4.0.3)
-      '@angular/build': 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.0)(typescript@5.9.3)
+      '@angular/build': 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.1)(typescript@5.9.3)
       '@angular/compiler-cli': 20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3)
       '@babel/core': 7.28.3
       '@babel/generator': 7.28.3
@@ -8345,7 +8345,7 @@ snapshots:
       '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.0)(typescript@5.9.3)':
+  '@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.1)(typescript@5.9.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.26(chokidar@4.0.3)
@@ -8355,7 +8355,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.14(@types/node@25.8.0)
-      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0))
+      '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1))
       beasties: 0.3.5
       browserslist: 4.28.2
       esbuild: 0.28.0
@@ -8375,7 +8375,7 @@ snapshots:
       tinyglobby: 0.2.14
       tslib: 2.8.1
       typescript: 5.9.3
-      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0)
+      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1)
       watchpack: 2.4.4
     optionalDependencies:
       '@angular/core': 20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)
@@ -10312,9 +10312,9 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.28.0)(postcss@8.5.12)
 
-  '@ngx-env/builder@20.1.1(@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.0)(typescript@5.9.3))(webpack@5.105.0(postcss@8.5.12))':
+  '@ngx-env/builder@20.1.1(@angular/build@20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.1)(typescript@5.9.3))(webpack@5.105.0(postcss@8.5.12))':
     dependencies:
-      '@angular/build': 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.0)(typescript@5.9.3)
+      '@angular/build': 20.3.26(@angular/compiler-cli@20.3.21(@angular/compiler@20.3.21)(typescript@5.9.3))(@angular/compiler@20.3.21)(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(@angular/platform-browser@20.3.21(@angular/animations@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@angular/common@20.3.21(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@20.3.21(@angular/compiler@20.3.21)(rxjs@7.8.2)))(@types/node@25.8.0)(chokidar@4.0.3)(jiti@2.7.0)(karma@6.4.4)(less@4.4.0)(postcss@8.5.12)(terser@5.43.1)(tslib@2.8.1)(tsx@4.22.1)(typescript@5.9.3)
       glob: 10.5.0
     optionalDependencies:
       '@dotenv-run/webpack': 1.5.2(webpack@5.105.0(postcss@8.5.12))
@@ -11608,9 +11608,9 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0))':
+  '@vitejs/plugin-basic-ssl@2.1.0(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1))':
     dependencies:
-      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0)
+      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1)
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -11621,13 +11621,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0))':
+  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0)
+      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -14793,13 +14793,13 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.12
-      tsx: 4.22.0
+      tsx: 4.22.1
 
   postcss-loader@8.1.1(postcss@8.5.12)(typescript@5.9.3)(webpack@5.105.0(postcss@8.5.12)):
     dependencies:
@@ -15749,7 +15749,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -15760,7 +15760,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1)
       resolve-from: 5.0.0
       rollup: 4.60.4
       source-map: 0.7.6
@@ -15777,7 +15777,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.22.0:
+  tsx@4.22.1:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:
@@ -16177,7 +16177,7 @@ snapshots:
       vega-voronoi: 5.1.0
       vega-wordcloud: 5.1.0
 
-  vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0):
+  vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16192,12 +16192,12 @@ snapshots:
       less: 4.4.0
       sass: 1.90.0
       terser: 5.43.1
-      tsx: 4.22.0
+      tsx: 4.22.1
 
-  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0))
+      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -16214,7 +16214,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.0)
+      vite: 7.3.2(@types/node@25.8.0)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.43.1)(tsx@4.22.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     prettier:
       specifier: ^3.8.3
       version: 3.8.3
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
     tsx:
       specifier: ^4.22.0
       version: 4.22.1
@@ -238,6 +241,9 @@ importers:
       '@types/express':
         specifier: 'catalog:'
         version: 4.17.25
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1)(typescript@5.9.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.1
@@ -16183,7 +16189,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.12
-      rollup: 4.59.0
+      rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,18 +12,33 @@ catalogs:
     '@types/express':
       specifier: ^4.17.25
       version: 4.17.25
+    '@types/node':
+      specifier: ^24.12.3
+      version: 24.12.4
     axios:
       specifier: ~1.15.2
       version: 1.15.2
+    dotenv:
+      specifier: ^16.6.1
+      version: 16.6.1
     express:
       specifier: ^4.22.1
       version: 4.22.2
+    ol:
+      specifier: ^10.9.0
+      version: 10.9.0
+    prettier:
+      specifier: ^3.8.3
+      version: 3.8.3
     tsx:
       specifier: ^4.22.0
       version: 4.22.0
     typescript:
       specifier: ~5.9.3
       version: 5.9.3
+    vitest:
+      specifier: ^4.1.6
+      version: 4.1.6
     zod:
       specifier: ^3.25.76
       version: 3.25.76
@@ -11912,7 +11927,7 @@ snapshots:
 
   axios@1.15.2:
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -13237,8 +13252,6 @@ snapshots:
   flatted@3.4.2: {}
 
   fn.name@1.1.0: {}
-
-  follow-redirects@1.16.0: {}
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,33 +12,18 @@ catalogs:
     '@types/express':
       specifier: ^4.17.25
       version: 4.17.25
-    '@types/node':
-      specifier: ^24.12.3
-      version: 24.12.4
     axios:
       specifier: ~1.15.2
       version: 1.15.2
-    dotenv:
-      specifier: ^16.6.1
-      version: 16.6.1
     express:
       specifier: ^4.22.1
       version: 4.22.2
-    ol:
-      specifier: ^10.9.0
-      version: 10.9.0
-    prettier:
-      specifier: ^3.8.3
-      version: 3.8.3
     tsx:
       specifier: ^4.22.0
       version: 4.22.0
     typescript:
       specifier: ~5.9.3
       version: 5.9.3
-    vitest:
-      specifier: ^4.1.6
-      version: 4.1.6
     zod:
       specifier: ^3.25.76
       version: 3.25.76
@@ -225,9 +210,9 @@ importers:
       winston:
         specifier: ^3.17.0
         version: 3.19.0
-      winston-transport-sentry-node:
-        specifier: ^3.0.0
-        version: 3.0.0(@sentry/node@10.53.1)
+      winston-sentry-javascript-node:
+        specifier: ^0.2.2
+        version: 0.2.2(winston@3.19.0)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -3266,6 +3251,18 @@ packages:
     resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
     engines: {node: '>=18'}
 
+  '@sentry/core@5.30.0':
+    resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
+    engines: {node: '>=6'}
+
+  '@sentry/hub@5.30.0':
+    resolution: {integrity: sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==}
+    engines: {node: '>=6'}
+
+  '@sentry/minimal@5.30.0':
+    resolution: {integrity: sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==}
+    engines: {node: '>=6'}
+
   '@sentry/node-core@10.53.1':
     resolution: {integrity: sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==}
     engines: {node: '>=18'}
@@ -3294,6 +3291,10 @@ packages:
     resolution: {integrity: sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==}
     engines: {node: '>=18'}
 
+  '@sentry/node@5.30.0':
+    resolution: {integrity: sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==}
+    engines: {node: '>=6'}
+
   '@sentry/opentelemetry@10.53.1':
     resolution: {integrity: sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==}
     engines: {node: '>=18'}
@@ -3302,6 +3303,18 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/tracing@5.30.0':
+    resolution: {integrity: sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==}
+    engines: {node: '>=6'}
+
+  '@sentry/types@5.30.0':
+    resolution: {integrity: sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==}
+    engines: {node: '>=6'}
+
+  '@sentry/utils@5.30.0':
+    resolution: {integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==}
+    engines: {node: '>=6'}
 
   '@sigstore/bundle@4.0.0':
     resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
@@ -4356,6 +4369,10 @@ packages:
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -5894,6 +5911,9 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lru_map@0.3.3:
+    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -7928,11 +7948,10 @@ packages:
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
-  winston-transport-sentry-node@3.0.0:
-    resolution: {integrity: sha512-KT3peOJtKytdF/nInt7XWtqMwbc7M/O5nSACTEdCkuVxZL7d30dDQ9GNHq0evcP2p73Ztg3gAPuZnBX8Qns2QA==}
-    engines: {node: '>= 8.10.0'}
+  winston-sentry-javascript-node@0.2.2:
+    resolution: {integrity: sha512-gKrx8Vx70t6OeoTRbDRuV+Giv2xNzMz0JaCw0Z8Ojhioo4sF6G9xPd18KXSE29tXE81R0ml3xKqRoQI7LVMwnA==}
     peerDependencies:
-      '@sentry/node': ^8.13.0
+      winston: '>= 3.x'
 
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
@@ -10984,6 +11003,26 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
+  '@sentry/core@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/minimal': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/hub@5.30.0':
+    dependencies:
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/minimal@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/types': 5.30.0
+      tslib: 1.14.1
+
   '@sentry/node-core@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@sentry/core': 10.53.1
@@ -11031,6 +11070,20 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
+  '@sentry/node@5.30.0':
+    dependencies:
+      '@sentry/core': 5.30.0
+      '@sentry/hub': 5.30.0
+      '@sentry/tracing': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      cookie: 0.4.2
+      https-proxy-agent: 5.0.1
+      lru_map: 0.3.3
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@sentry/opentelemetry@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11038,6 +11091,21 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry/core': 10.53.1
+
+  '@sentry/tracing@5.30.0':
+    dependencies:
+      '@sentry/hub': 5.30.0
+      '@sentry/minimal': 5.30.0
+      '@sentry/types': 5.30.0
+      '@sentry/utils': 5.30.0
+      tslib: 1.14.1
+
+  '@sentry/types@5.30.0': {}
+
+  '@sentry/utils@5.30.0':
+    dependencies:
+      '@sentry/types': 5.30.0
+      tslib: 1.14.1
 
   '@sigstore/bundle@4.0.0':
     dependencies:
@@ -11844,7 +11912,7 @@ snapshots:
 
   axios@1.15.2:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -12280,6 +12348,8 @@ snapshots:
   cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
+
+  cookie@0.4.2: {}
 
   cookie@0.7.2: {}
 
@@ -13168,6 +13238,8 @@ snapshots:
 
   fn.name@1.1.0: {}
 
+  follow-redirects@1.16.0: {}
+
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -14019,6 +14091,8 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lru_map@0.3.3: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -16313,13 +16387,12 @@ snapshots:
 
   wildcard@2.0.1: {}
 
-  winston-transport-sentry-node@3.0.0(@sentry/node@10.53.1):
+  winston-sentry-javascript-node@0.2.2(winston@3.19.0):
     dependencies:
-      '@sentry/node': 10.53.1
-      triple-beam: 1.4.1
-      tslib: 2.8.1
+      '@sentry/node': 5.30.0
       winston: 3.19.0
-      winston-transport: 4.9.0
+    transitivePeerDependencies:
+      - supports-color
 
   winston-transport@4.9.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,9 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.12)(tsx@4.22.1)(typescript@5.9.3)
       tsx:
         specifier: 'catalog:'
         version: 4.22.1
@@ -12817,9 +12820,9 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       semver: 7.8.0
 
-  eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)
 
   eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
@@ -12863,7 +12866,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
       prettier: 3.8.3
@@ -12871,7 +12874,7 @@ snapshots:
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@10.4.0(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
   eslint-scope@5.1.1:
     dependencies:
@@ -13433,9 +13436,9 @@ snapshots:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       chalk: 4.1.2
       eslint: 9.39.4(jiti@2.7.0)
-      eslint-config-prettier: 10.1.8(eslint@10.4.0(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       execa: 5.1.1
       inquirer: 7.3.3
       json5: 2.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,9 +386,6 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.971.0
         version: 3.1048.0
-      '@types/jest':
-        specifier: ^29.5.12
-        version: 29.5.14
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -2155,18 +2152,6 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
-  '@jest/expect-utils@29.7.0':
-    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jest/schemas@29.6.3':
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jest/types@29.6.3':
-    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -3339,9 +3324,6 @@ packages:
     resolution: {integrity: sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@sinclair/typebox@0.27.10':
-    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
-
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
@@ -3514,20 +3496,8 @@ packages:
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
-  '@types/istanbul-lib-coverage@2.0.6':
-    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
-
-  '@types/istanbul-lib-report@3.0.3':
-    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
-
-  '@types/istanbul-reports@3.0.4':
-    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-
   '@types/jasmine@5.1.15':
     resolution: {integrity: sha512-ZAC8KjmV2MJxbNTrwXFN+HKeajpXQZp6KpPiR6Aa4XvaEnjP6qh23lL/Rqb7AYzlp3h/rcwDrQ7Gg7q28cQTQg==}
-
-  '@types/jest@29.5.14':
-    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/js-levenshtein@1.1.3':
     resolution: {integrity: sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ==}
@@ -3619,9 +3589,6 @@ packages:
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
 
-  '@types/stack-utils@2.0.3':
-    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
 
@@ -3636,12 +3603,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.35':
-    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript-eslint/eslint-plugin@8.59.3':
     resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
@@ -3901,10 +3862,6 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -4214,10 +4171,6 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -4637,10 +4590,6 @@ packages:
   di@0.0.1:
     resolution: {integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==}
 
-  diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
@@ -4834,10 +4783,6 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
-  escape-string-regexp@2.0.0:
-    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
-    engines: {node: '>=8'}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -4990,10 +4935,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  expect@29.7.0:
-    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -5667,26 +5608,6 @@ packages:
 
   jasmine-core@5.6.0:
     resolution: {integrity: sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==}
-
-  jest-diff@29.7.0:
-    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-get-type@29.6.3:
-    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-matcher-utils@29.7.0:
-    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-message-util@29.7.0:
-    resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-util@29.7.0:
-    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -6716,10 +6637,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   prisma@6.19.3:
     resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
     engines: {node: '>=18.18'}
@@ -6824,9 +6741,6 @@ packages:
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
-
-  react-is@18.3.1:
-    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -7155,10 +7069,6 @@ packages:
     resolution: {integrity: sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -7246,10 +7156,6 @@ packages:
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
-
-  stack-utils@2.0.6:
-    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
-    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -10064,23 +9970,6 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
-  '@jest/expect-utils@29.7.0':
-    dependencies:
-      jest-get-type: 29.6.3
-
-  '@jest/schemas@29.6.3':
-    dependencies:
-      '@sinclair/typebox': 0.27.10
-
-  '@jest/types@29.6.3':
-    dependencies:
-      '@jest/schemas': 29.6.3
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.4
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -11179,8 +11068,6 @@ snapshots:
       '@sigstore/core': 3.2.0
       '@sigstore/protobuf-specs': 0.5.1
 
-  '@sinclair/typebox@0.27.10': {}
-
   '@sindresorhus/base62@1.0.0': {}
 
   '@smithy/core@3.24.3':
@@ -11363,22 +11250,7 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
-  '@types/istanbul-lib-coverage@2.0.6': {}
-
-  '@types/istanbul-lib-report@3.0.3':
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.6
-
-  '@types/istanbul-reports@3.0.4':
-    dependencies:
-      '@types/istanbul-lib-report': 3.0.3
-
   '@types/jasmine@5.1.15': {}
-
-  '@types/jest@29.5.14':
-    dependencies:
-      expect: 29.7.0
-      pretty-format: 29.7.0
 
   '@types/js-levenshtein@1.1.3': {}
 
@@ -11486,8 +11358,6 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
-  '@types/stack-utils@2.0.3': {}
-
   '@types/superagent@8.1.9':
     dependencies:
       '@types/cookiejar': 2.1.5
@@ -11509,12 +11379,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.8.0
-
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.35':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -11904,8 +11768,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@5.2.0: {}
-
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -12252,8 +12114,6 @@ snapshots:
   chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
-
-  ci-info@3.9.0: {}
 
   citty@0.1.6:
     dependencies:
@@ -12623,8 +12483,6 @@ snapshots:
 
   di@0.0.1: {}
 
-  diff-sequences@29.6.3: {}
-
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
@@ -12858,8 +12716,6 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
-  escape-string-regexp@2.0.0: {}
-
   escape-string-regexp@4.0.0: {}
 
   eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@2.7.0)):
@@ -13081,14 +12937,6 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expect-type@1.3.0: {}
-
-  expect@29.7.0:
-    dependencies:
-      '@jest/expect-utils': 29.7.0
-      jest-get-type: 29.6.3
-      jest-matcher-utils: 29.7.0
-      jest-message-util: 29.7.0
-      jest-util: 29.7.0
 
   exponential-backoff@3.1.3: {}
 
@@ -13854,43 +13702,6 @@ snapshots:
   jasmine-core@4.6.1: {}
 
   jasmine-core@5.6.0: {}
-
-  jest-diff@29.7.0:
-    dependencies:
-      chalk: 4.1.2
-      diff-sequences: 29.6.3
-      jest-get-type: 29.6.3
-      pretty-format: 29.7.0
-
-  jest-get-type@29.6.3: {}
-
-  jest-matcher-utils@29.7.0:
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.7.0
-      jest-get-type: 29.6.3
-      pretty-format: 29.7.0
-
-  jest-message-util@29.7.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@jest/types': 29.6.3
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
-
-  jest-util@29.7.0:
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 24.12.4
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.2
 
   jest-worker@27.5.1:
     dependencies:
@@ -14967,12 +14778,6 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  pretty-format@29.7.0:
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
-
   prisma@6.19.3(typescript@5.9.3):
     dependencies:
       '@prisma/config': 6.19.3
@@ -15065,8 +14870,6 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
-
-  react-is@18.3.1: {}
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -15484,8 +15287,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  slash@3.0.0: {}
-
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -15611,10 +15412,6 @@ snapshots:
       minipass: 7.1.3
 
   stack-trace@0.0.10: {}
-
-  stack-utils@2.0.6:
-    dependencies:
-      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   ol: '^10.9.0'
   prettier: '^3.8.3'
   tsx: '^4.22.0'
+  tsup: '^8.5.1'
   typescript: '~5.9.3'
   vitest: '^4.1.6'
   zod: '^3.25.76'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
 
 catalog:
+  '@sentry/node': '^10.53.1'
   '@types/express': '^4.17.25'
   '@types/node': '^24.12.3'
   axios: '~1.15.2'
@@ -11,7 +12,7 @@ catalog:
   prettier: '^3.8.3'
   tsx: '^4.22.0'
   typescript: '~5.9.3'
-  vitest: "^4.1.6"
+  vitest: '^4.1.6'
   zod: '^3.25.76'
 
 minimumReleaseAge: 2880


### PR DESCRIPTION
Fix web-api and capacity-manager blocking cdk deploy

* a bit more cleanup of Dockerfile and GitHub workflows
* need different winston transport lib that supports ESM

